### PR TITLE
Manually set rubocop config

### DIFF
--- a/lib/slim_lint/linter.rb
+++ b/lib/slim_lint/linter.rb
@@ -16,8 +16,11 @@ module SlimLint
     # Initializes a linter with the specified configuration.
     #
     # @param config [Hash] configuration for this linter
-    def initialize(config)
+    # @param options [Hash]
+    # @option (see Runner#run)
+    def initialize(config, options = {})
       @config = config
+      @options = options
       @lints = []
     end
 
@@ -40,7 +43,7 @@ module SlimLint
 
     private
 
-    attr_reader :config, :document
+    attr_reader :config, :options, :document
 
     # Record a lint for reporting back to the user.
     #

--- a/lib/slim_lint/linter/rubocop.rb
+++ b/lib/slim_lint/linter/rubocop.rb
@@ -51,7 +51,7 @@ module SlimLint
     # @param file [String]
     # @return [Array<RuboCop::Cop::Offense>]
     def lint_file(rubocop, file)
-      rubocop.run(%w[--format SlimLint::OffenseCollector] << file)
+      rubocop.run(rubocop_settings << file)
       OffenseCollector.offenses
     end
 
@@ -68,6 +68,17 @@ module SlimLint
                            source_map[offense.line],
                            "#{offense.cop_name}: #{offense.message}")
       end
+    end
+
+    # Returns settings for the rubocop CLI
+    #
+    # @return [Array<String>]
+    def rubocop_settings
+      settings = %w[--format SlimLint::OffenseCollector]
+      if options['rubocop_config_file']
+        settings << %w[--config #{options['rubocop_config_file']}]
+      end
+      settings
     end
   end
 

--- a/lib/slim_lint/linter_selector.rb
+++ b/lib/slim_lint/linter_selector.rb
@@ -41,7 +41,7 @@ module SlimLint
       # linters which are enabled in the configuration
       linters = (included_linters - excluded_linters).map do |linter_class|
         linter_config = config.for_linter(linter_class)
-        linter_class.new(linter_config) if linter_config['enabled']
+        linter_class.new(linter_config, options) if linter_config['enabled']
       end.compact
 
       # Highlight condition where all linters were filtered out, as this was

--- a/lib/slim_lint/options.rb
+++ b/lib/slim_lint/options.rb
@@ -67,6 +67,11 @@ module SlimLint
         @options[:config_file] = conf_file
       end
 
+      parser.on('--rubocop-config config-file', String,
+                'Specify which rubocop configuration file you want to use') do |rubocop_conf_file|
+        @options[:rubocop_config_file] = rubocop_conf_file
+      end
+
       parser.on('-e', '--exclude file,...', Array,
                 'List of file names to exclude') do |files|
         @options[:excluded_files] = files

--- a/lib/slim_lint/runner.rb
+++ b/lib/slim_lint/runner.rb
@@ -6,6 +6,7 @@ module SlimLint
     #
     # @param [Hash] options
     # @option options :config_file [String] path of configuration file to load
+    # @option options :rubocop_config_file [String] path of rubocop config file
     # @option options :config [SlimLint::Configuration] configuration to use
     # @option options :excluded_files [Array<String>]
     # @option options :included_linters [Array<String>]
@@ -30,6 +31,7 @@ module SlimLint
     # specified options.
     #
     # @param options [Hash]
+    # @option (see #run)
     # @return [SlimLint::Configuration]
     def load_applicable_config(options)
       if options[:config_file]
@@ -64,6 +66,7 @@ module SlimLint
     #
     # @param config [SlimLint::Configuration]
     # @param options [Hash]
+    # @option (see #run)
     # @return [Array<String>]
     def extract_applicable_files(config, options)
       included_patterns = options[:files]

--- a/spec/slim_lint/options_spec.rb
+++ b/spec/slim_lint/options_spec.rb
@@ -15,6 +15,14 @@ describe SlimLint::Options do
       end
     end
 
+    context 'with a rubocop configuration file specified' do
+      let(:args) { %w[--rubocop-config some-config.yml] }
+
+      it 'sets the `rubocop_config_file` option to that file path' do
+        subject.should include rubocop_config_file: 'some-config.yml'
+      end
+    end
+
     context 'with a list of files to exclude' do
       let(:args) { %w[--exclude some-glob-pattern/*.slim,some-other-pattern.slim] }
 


### PR DESCRIPTION
I'm looking to add this option to support the SublimeLinter plugin I'm writing (see [related issue](https://github.com/elstgav/SublimeLinter-slim-lint/issues/1)). The main problem I've run into is that while editing your files, SublimeLinter will create a temporary copy to lint. Since the tmp file is in a separate directory, rubocop won't correctly determine the config location (the slim config, however, is manually set).

This would also allow users to keep a separate rubocop configuration for their slim files if they so choose. We may want to add an option to hardcode the rubocop config as well in `slim-lint.yml`.

Looking for guidance on the feasibility of this approach as well as how to properly test this feature. I would imagine it would be useful to integrate with other linters (e.g. jshint, scss-lint) for the other languages slim supports, so this approach may not be feasible as the number grows.