### PR TITLE
Set rubocop config with environment variable

### DIFF
--- a/lib/slim_lint/linter/rubocop.rb
+++ b/lib/slim_lint/linter/rubocop.rb
@@ -75,7 +75,7 @@ module SlimLint
     # @return [Array<String>]
     def rubocop_settings
       settings = %w[--format SlimLint::OffenseCollector]
-      settings << %w[--config #{ENV['RUBOCOP_CONFIG']}] if ENV['RUBOCOP_CONFIG'].present?
+      settings += ['--config', ENV['RUBOCOP_CONFIG']] if ENV['RUBOCOP_CONFIG']
       settings
     end
   end

--- a/lib/slim_lint/linter/rubocop.rb
+++ b/lib/slim_lint/linter/rubocop.rb
@@ -51,7 +51,7 @@ module SlimLint
     # @param file [String]
     # @return [Array<RuboCop::Cop::Offense>]
     def lint_file(rubocop, file)
-      rubocop.run(%w[--format SlimLint::OffenseCollector] << file)
+      rubocop.run(rubocop_settings << file)
       OffenseCollector.offenses
     end
 
@@ -68,6 +68,15 @@ module SlimLint
                            source_map[offense.line],
                            "#{offense.cop_name}: #{offense.message}")
       end
+    end
+
+    # Returns settings for the rubocop CLI
+    #
+    # @return [Array<String>]
+    def rubocop_settings
+      settings = %w[--format SlimLint::OffenseCollector]
+      settings << %w[--config #{ENV['RUBOCOP_CONFIG']}] if ENV['RUBOCOP_CONFIG'].present?
+      settings
     end
   end
 


### PR DESCRIPTION
Re-worked from #5:

> I'm looking to add this option to support the SublimeLinter plugin I'm writing (see [related issue](https://github.com/elstgav/SublimeLinter-slim-lint/issues/1)). The main problem I've run into is that while editing your files, SublimeLinter will create a temporary copy to lint. Since the tmp file is in a separate directory, rubocop won't correctly determine the config location (the slim-lint config, however, is manually set).

> This would also allow users to keep a separate rubocop configuration for their slim files if they so choose. 

As suggested, this pull request lets you set the config with an environment variable. 

Things left to do:

- [ ] Add a note to the documentation
- [ ] Test the functionality. **I'm not sure how to set that test up though; would I need to create a dummy `.rubocop.yml` file?**