### PR TITLE
Remove cop name from rubocop offense

### DIFF
--- a/lib/slim_lint/linter/rubocop.rb
+++ b/lib/slim_lint/linter/rubocop.rb
@@ -66,7 +66,7 @@ module SlimLint
         @lints << Lint.new(self,
                            document.file,
                            source_map[offense.line],
-                           "#{offense.cop_name}: #{offense.message}")
+                           offense.message)
       end
     end
 


### PR DESCRIPTION
Rubocop already prints out its cop name in the offense message if you have it configured to do so (in which case you would see the cop name twice).

Before:
```shell
[W] RuboCop: Lint/UselessAssignment: Lint/UselessAssignment: Useless assignment to variable - `foo`.
```

After:
```shell
[W] RuboCop: Lint/UselessAssignment: Useless assignment to variable - `foo`.
```

You can turn on the display of cop names in your `.rubocop.yml`:
```yml
AllCops:
  DisplayCopNames: true
```