### PR TITLE
Require Ruby 1.9.3 or higher

### DIFF
--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files            = Dir['config/**.yml'] +
                        Dir['lib/**/*.rb']
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'slim', '~> 3.0'
   s.add_dependency 'rubocop', '>= 0.25.0'


### PR DESCRIPTION
The reason for this change is below.

* Travis CI tests Ruby 1.9.3.(https://github.com/sds/slim-lint/blob/master/.travis.yml)
* README.md says that Ruby 1.9.3+.(https://github.com/sds/slim-lint/blob/master/README.md#requirements)