### PR TITLE
Fix using bare raise_error matcher

### DIFF
--- a/spec/slim_lint/rake_task_spec.rb
+++ b/spec/slim_lint/rake_task_spec.rb
@@ -35,7 +35,7 @@ describe SlimLint::RakeTask do
     let(:slim) { '%tag' }
 
     it 'raises an error' do
-      expect { run_task }.to raise_error
+      expect { run_task }.to raise_error RuntimeError
     end
   end
 end


### PR DESCRIPTION
 I execute `rspec spec` and gets warning on rspec.
 I fix it.

Thank you!