### PR TITLE
Ignore Rubocop's new ExtraSpacing linter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -37,6 +37,7 @@ linters:
       - Style/AlignHash
       - Style/AlignParameters
       - Style/BlockNesting
+      - Style/ExtraSpacing
       - Style/FileName
       - Style/FirstParameterIndentation
       - Style/IfUnlessModifier


### PR DESCRIPTION
It's pretty useless in slim files