### PR TITLE
Add Style/FrozenStringLiteralComment to ignored rubocop cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -39,6 +39,7 @@ linters:
       - Style/BlockNesting
       - Style/FileName
       - Style/FirstParameterIndentation
+      - Style/FrozenStringLiteralComment
       - Style/IfUnlessModifier
       - Style/IndentationConsistency
       - Style/IndentationWidth


### PR DESCRIPTION
Rubocop 0.37.1 wants to add `# frozen_string_literal: true` to the beginning of each file (when targeting ruby 2.3.0). 

It shouldn't suggest that for slim files.