### PR TITLE
Ignore Style/MultilineOperationIndentation cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -43,6 +43,7 @@ linters:
       - Style/IfUnlessModifier
       - Style/IndentationConsistency
       - Style/IndentationWidth
+      - Style/MultilineOperationIndentation
       - Style/Next
       - Style/TrailingBlankLines
       - Style/TrailingWhitespace


### PR DESCRIPTION
This cop prevents from having slim markup spanning on multiple lines.