### PR TITLE
Fix EmptyControlStatement spelling

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -15,7 +15,7 @@ linters:
     enabled: true
     max_consecutive: 2
 
-  EmptyControlStatment:
+  EmptyControlStatement:
     enabled: true
 
   ExplicitDiv:


### PR DESCRIPTION
Was originally `EmptyControlStatment` which of course is a misspelling.