### PR TITLE
Fix default.yml to use `RedundantDiv`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -18,7 +18,7 @@ linters:
   EmptyControlStatement:
     enabled: true
 
-  ExplicitDiv:
+  RedundantDiv:
     enabled: true
 
   LineLength:


### PR DESCRIPTION
`ExplicitDiv` appears to be the old name for `RedundantDiv` so I have updated the file accordingly.

I think this adds further credence to https://github.com/sds/slim-lint/issues/32