### PR TITLE
Add Multiline cops to ignored_cops list

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -45,6 +45,13 @@ linters:
       - Style/IfUnlessModifier
       - Style/IndentationConsistency
       - Style/IndentationWidth
+      - Style/MultilineArrayBraceLayout
+      - Style/MultilineAssignmentLayout
+      - Style/MultilineHashBraceLayout
+      - Style/MultilineMethodCallBraceLayout
+      - Style/MultilineMethodDefinitionBraceLayout
+      - Style/MultilineMethodCallIndentation
+      - Style/MultilineOperationIndentation
       - Style/Next
       - Style/TrailingBlankLines
       - Style/TrailingWhitespace


### PR DESCRIPTION
These cops don't make sense since they run on processed output,
any attempt to fix the errors these cops produce by changing
the slim files is futile.