### PR TITLE
skip_frontmatter does not work as expected

### DIFF
--- a/lib/slim_lint/document.rb
+++ b/lib/slim_lint/document.rb
@@ -44,7 +44,7 @@ module SlimLint
       @source_lines = @source.split("\n")
 
       engine = SlimLint::Engine.new(file: @file)
-      @sexp = engine.parse(source)
+      @sexp = engine.parse(@source)
     end
 
     # Ensure the string's encoding is valid.


### PR DESCRIPTION
`skip_frontmatter` does not works as expected.

Even when you set it as `skip_frontmatter: true`, slim-lint always warns about offensive things within frontmatter.

After some investigation, I've found that `Document` class's `sexp` attribute must be generated by stripped `source`, otherwise there still exist frontmatter in `sexp`.