### PR TITLE
Add RuboCop 0.47.0 compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ Lint/AssignmentInCondition:
 Lint/Void:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
 Metrics/LineLength:
   Max: 100
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gemspec
 gem 'overcommit', '0.37.0'
 
 # Pin tool versions (which are executed by Overcommit) for Travis builds
-gem 'rubocop', '0.46.0'
+gem 'rubocop', '0.47.0'
 
 gem 'coveralls', require: false

--- a/lib/slim_lint/ruby_parser.rb
+++ b/lib/slim_lint/ruby_parser.rb
@@ -1,5 +1,5 @@
 require 'rubocop'
-require 'rubocop/ast_node/builder'
+require 'rubocop/ast/builder'
 require 'parser/current'
 
 module SlimLint
@@ -11,7 +11,7 @@ module SlimLint
   class RubyParser
     # Creates a reusable parser.
     def initialize
-      @builder = ::RuboCop::Node::Builder.new
+      @builder = ::RuboCop::AST::Builder.new
       @parser = ::Parser::CurrentRuby.new(@builder)
     end
 

--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'slim', '~> 3.0'
   s.add_dependency 'rake', '>= 10', '< 13'
-  s.add_dependency 'rubocop', '>= 0.36.0'
+  s.add_dependency 'rubocop', '>= 0.47.0'
   s.add_dependency 'sysexits', '~> 1.1'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
A `Node` classes reorganization in RuboCop broke compatibility with
slim lint. This PR allows to use slim-lint with RuboCop 0.47.0

Ref: bbatsov/rubocop@48f1637eb36575a95b2004fecd3212d848d64f59