### PR TITLE
Add RuboCop 0.48.0 compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,3 +106,11 @@ Style/TrailingCommaInArguments:
 
 Style/TrailingCommaInLiteral:
   Enabled: false
+
+# Disabling some new rubocop 0.48 cops to avoid distracting clutter in a PR
+# (Should be enabled and auto-corrected in a follow-up PR.)
+Style/InverseMethods:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gemspec
 gem 'overcommit', '0.37.0'
 
 # Pin tool versions (which are executed by Overcommit) for Travis builds
-gem 'rubocop', '0.47.0'
+gem 'rubocop', '0.48.0'
 
 gem 'coveralls', require: false

--- a/lib/slim_lint/linter/rubocop.rb
+++ b/lib/slim_lint/linter/rubocop.rb
@@ -34,7 +34,7 @@ module SlimLint
       filename = "#{File.basename(original_filename)}.slim_lint.tmp"
       directory = File.dirname(original_filename)
 
-      Tempfile.open(filename, directory) do |f|
+      Tempfile.open([filename, '.rb'], directory) do |f|
         begin
           f.write(ruby)
           f.close

--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'slim', '~> 3.0'
   s.add_dependency 'rake', '>= 10', '< 13'
-  s.add_dependency 'rubocop', '>= 0.47.0'
+  s.add_dependency 'rubocop', '>= 0.48.0'
   s.add_dependency 'sysexits', '~> 1.1'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
RuboCop 0.48.0 excludes non-ruby files (see the `RuboCop::TargetFinder.ruby_file?` method).

slim-lint uses temporary files that were non-ruby-files according to RuboCop, so they were excluded, leading to slim-lint silently ignoring all RuboCop errors.

This PR changes slim-lint's Tempfile creation to ensure RuboCop picks up the files.

Ref: bbatsov/rubocop@c2a9848