### PR TITLE
Correct BlockNesting in ignored_cops defaults

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -53,8 +53,8 @@ linters:
       - Lint/EndAlignment
       - Lint/Void
       - Metrics/BlockLength
+      - Metrics/BlockNesting
       - Metrics/LineLength
-      - Style/BlockNesting
       - Style/FileName
       - Style/FrozenStringLiteralComment
       - Style/IfUnlessModifier


### PR DESCRIPTION
Why?
- Rubocop has moved BlockNesting from Style to Metrics