### PR TITLE
Disable some rubocop array rules

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -35,9 +35,11 @@ linters:
     # WARNING: If you define this list in your own .slim-lint.yml file, you'll
     # be overriding the list defined here.
     ignored_cops:
+      - Layout/AlignArray
       - Layout/AlignHash
       - Layout/AlignParameters
       - Layout/FirstParameterIndentation
+      - Layout/IndentArray
       - Layout/IndentationConsistency
       - Layout/IndentationWidth
       - Layout/MultilineArrayBraceLayout


### PR DESCRIPTION
Sometimes it is nice to split an array over multiple lines in slim:
(This is especially helpful if line lenght would be too long otherwise.)

```slim
- [a, b, c,
   d, e, f].each do |el|

/ or (little bit ugly)

- [ \
   a, b, c,
   d, e, f \
  ].each do |el|
```

This always lead to the rubocop warnings now disabled.