### PR TITLE
Ingore FileName cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -57,6 +57,7 @@ linters:
       - Metrics/BlockLength
       - Metrics/BlockNesting
       - Metrics/LineLength
+      - Naming/FileName
       - Style/FileName
       - Style/FrozenStringLiteralComment
       - Style/IfUnlessModifier


### PR DESCRIPTION
Otherwise we get an error for each slim file like this starting with rubocop 0.50:

RuboCop: Naming/FileName: The name of this source file
(`.....html.slim.slim_lint.tmp20170918-9415-l0wr3l.rb`) should use
snake_case