### PR TITLE
Switch RuboCop mode to read from stdin

### DIFF
--- a/lib/slim_lint/linter/rubocop.rb
+++ b/lib/slim_lint/linter/rubocop.rb
@@ -29,7 +29,12 @@ module SlimLint
     def find_lints(ruby, source_map)
       rubocop = ::RuboCop::CLI.new
 
-      filename = document.file || 'ruby_script'
+      filename =
+        if document.file
+          "#{document.file}.rb"
+        else
+          'ruby_script.rb'
+        end
 
       with_ruby_from_stdin(ruby) do
         extract_lints_from_offenses(lint_file(rubocop, filename), source_map)


### PR DESCRIPTION
Currently, slim-lint runs the RuboCop linter from a Tempfile. This works
well in traditional environments, but fails in constrained environments
like Docker containers that have their data mounted as read-only
volumes.

This changes the RuboCop linter to run via an overridden STDIN. By
overriding the global `$stdin` variable, we can trick RuboCop into
believing it is reading directly from the STDIN. This means that we
don't have to generate Tempfiles for each file we want to lint which
will allow slim-lint to work within the confines of a Docker container.

Closes: #69