### PR TITLE
Don't report "no blank line" if file is empty

### DIFF
--- a/lib/slim_lint/linter/trailing_blank_lines.rb
+++ b/lib/slim_lint/linter/trailing_blank_lines.rb
@@ -5,6 +5,7 @@ module SlimLint
 
     on_start do |_sexp|
       dummy_node = Struct.new(:line)
+      next if document.source.empty?
 
       if !document.source.end_with?("\n")
         report_lint(dummy_node.new(document.source_lines.size),

--- a/spec/slim_lint/linter/trailing_blank_lines_spec.rb
+++ b/spec/slim_lint/linter/trailing_blank_lines_spec.rb
@@ -32,4 +32,10 @@ describe SlimLint::Linter::TrailingBlankLines do
 
     it { should_not report_lint }
   end
+
+  context 'when source is empty' do
+    let(:slim) { '' }
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
Prior to this PR, there was no way to make slim-lint happy if a .slim file was completely blank. If the file was empty (0 bytes), then slim-lint would report:

```
empty.slim:0 [W] TrailingBlankLines: No blank line in the end of file
```

If a newline was added to address the above warning (i.e. such that the file contains exactly `\n`), then slim-lint would still complain, this time with different warnings:

```
empty.slim:1 [W] EmptyLines: Extra empty line detected
empty.slim:1 [W] TrailingBlankLines: Multiple empty lines in the end of file
```

This PR fixes the problem by gracefully handling empty files without reporting any warnings.