### PR TITLE
Support rubocop v0.53.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 # We break this rule to write S-expressions more succinctly.
+AllCops:
+  TargetRubyVersion: 2.2
+
 Layout/AlignArray:
   Exclude:
     - 'lib/slim_lint/filters/**/*.rb'
@@ -101,7 +104,10 @@ Style/TrivialAccessors:
 Style/TrailingCommaInArguments:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 
 # Disabling some new rubocop 0.48 cops to avoid distracting clutter in a PR
@@ -110,4 +116,7 @@ Style/InverseMethods:
   Enabled: false
 
 Style/SymbolArray:
+  Enabled: false
+
+Style/MutableConstant:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.1
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
 
 before_script:
   - git config --local user.email "travis@travis.ci"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec
@@ -6,6 +8,6 @@ gemspec
 gem 'overcommit', '0.41.0'
 
 # Pin tool versions (which are executed by Overcommit) for Travis builds
-gem 'rubocop', '0.51.0'
+gem 'rubocop', '0.53.0'
 
 gem 'coveralls', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'

--- a/bin/slim-lint
+++ b/bin/slim-lint
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'slim_lint/cli'
 

--- a/lib/slim_lint.rb
+++ b/lib/slim_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load all slim-lint modules necessary to parse and lint a file.
 # Ordering here can be important depending on class references in each module.
 

--- a/lib/slim_lint/atom.rb
+++ b/lib/slim_lint/atom.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Represents an atomic, childless, literal value within an S-expression.
   #

--- a/lib/slim_lint/capture_map.rb
+++ b/lib/slim_lint/capture_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Holds the list of captures, providing a convenient interface for accessing
   # the values and unwrapping them on your behalf.

--- a/lib/slim_lint/cli.rb
+++ b/lib/slim_lint/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slim_lint'
 require 'slim_lint/options'
 
@@ -54,23 +56,23 @@ module SlimLint
 
     # Outputs a message and returns an appropriate error code for the specified
     # exception.
-    def handle_exception(ex)
-      case ex
+    def handle_exception(exception)
+      case exception
       when SlimLint::Exceptions::ConfigurationError
-        log.error ex.message
+        log.error exception.message
         Sysexits::EX_CONFIG
       when SlimLint::Exceptions::InvalidCLIOption
-        log.error ex.message
+        log.error exception.message
         log.log "Run `#{APP_NAME}` --help for usage documentation"
         Sysexits::EX_USAGE
       when SlimLint::Exceptions::InvalidFilePath
-        log.error ex.message
+        log.error exception.message
         Sysexits::EX_NOINPUT
       when SlimLint::Exceptions::NoLintersError
-        log.error ex.message
+        log.error exception.message
         Sysexits::EX_NOINPUT
       else
-        print_unexpected_exception(ex)
+        print_unexpected_exception(exception)
         Sysexits::EX_SOFTWARE
       end
     end
@@ -135,9 +137,9 @@ module SlimLint
 
     # Outputs the backtrace of an exception with instructions on how to report
     # the issue.
-    def print_unexpected_exception(ex) # rubocop:disable Metrics/AbcSize
-      log.bold_error ex.message
-      log.error ex.backtrace.join("\n")
+    def print_unexpected_exception(exception) # rubocop:disable Metrics/AbcSize
+      log.bold_error exception.message
+      log.error exception.backtrace.join("\n")
       log.warning 'Report this bug at ', false
       log.info SlimLint::BUG_REPORT_URL
       log.newline

--- a/lib/slim_lint/configuration.rb
+++ b/lib/slim_lint/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Stores runtime configuration for the application.
   #

--- a/lib/slim_lint/configuration_loader.rb
+++ b/lib/slim_lint/configuration_loader.rb
@@ -7,7 +7,7 @@ module SlimLint
   # Manages configuration file loading.
   class ConfigurationLoader
     DEFAULT_CONFIG_PATH = File.join(SlimLint::HOME, 'config', 'default.yml').freeze
-    CONFIG_FILE_NAME = '.slim-lint.yml'.freeze
+    CONFIG_FILE_NAME = '.slim-lint.yml'
 
     class << self
       # Load configuration file given the current working directory the
@@ -25,7 +25,7 @@ module SlimLint
 
       # Loads the built-in default configuration.
       def default_configuration
-        @default_config ||= load_from_file(DEFAULT_CONFIG_PATH)
+        @default_configuration ||= load_from_file(DEFAULT_CONFIG_PATH)
       end
 
       # Loads a configuration, ensuring it extends the default configuration.

--- a/lib/slim_lint/constants.rb
+++ b/lib/slim_lint/constants.rb
@@ -3,8 +3,8 @@
 # Global application constants.
 module SlimLint
   HOME = File.expand_path(File.join(File.dirname(__FILE__), '..', '..')).freeze
-  APP_NAME = 'slim-lint'.freeze
+  APP_NAME = 'slim-lint'
 
-  REPO_URL = 'https://github.com/sds/slim-lint'.freeze
-  BUG_REPORT_URL = "#{REPO_URL}/issues".freeze
+  REPO_URL = 'https://github.com/sds/slim-lint'
+  BUG_REPORT_URL = "#{REPO_URL}/issues"
 end

--- a/lib/slim_lint/engine.rb
+++ b/lib/slim_lint/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Temple engine used to generate a {Sexp} parse tree for use by linters.
   #

--- a/lib/slim_lint/exceptions.rb
+++ b/lib/slim_lint/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Collection of exceptions that can be raised by the application.
 module SlimLint::Exceptions
   # Raised when a {Configuration} could not be loaded from a file.

--- a/lib/slim_lint/file_finder.rb
+++ b/lib/slim_lint/file_finder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'find'
 
 module SlimLint

--- a/lib/slim_lint/filters/attribute_processor.rb
+++ b/lib/slim_lint/filters/attribute_processor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint::Filters
   # A dumbed-down version of {Slim::CodeAttributes} which doesn't introduce any
   # temporary variables or other cruft.

--- a/lib/slim_lint/filters/control_processor.rb
+++ b/lib/slim_lint/filters/control_processor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint::Filters
   # A dumbed-down version of {Slim::Controls} which doesn't introduce temporary
   # variables and other cruft (which in the context of extracting Ruby code,

--- a/lib/slim_lint/filters/inject_line_numbers.rb
+++ b/lib/slim_lint/filters/inject_line_numbers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint::Filters
   # Traverses a Temple S-expression (that has already been converted to
   # {SlimLint::Sexp} instances) and annotates them with line numbers.

--- a/lib/slim_lint/filters/sexp_converter.rb
+++ b/lib/slim_lint/filters/sexp_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint::Filters
   # Converts a Temple S-expression comprised of {Array}s into {SlimLint::Sexp}s.
   #

--- a/lib/slim_lint/filters/splat_processor.rb
+++ b/lib/slim_lint/filters/splat_processor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint::Filters
   # A dumbed-down version of {Slim::Splat::Filter} which doesn't introduced
   # temporary variables or other cruft.

--- a/lib/slim_lint/lint.rb
+++ b/lib/slim_lint/lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Contains information about a problem or issue with a Slim document.
   class Lint

--- a/lib/slim_lint/linter.rb
+++ b/lib/slim_lint/linter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Base implementation for all lint checks.
   #

--- a/lib/slim_lint/linter/comment_control_statement.rb
+++ b/lib/slim_lint/linter/comment_control_statement.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Searches for control statements with only comments.
   class Linter::CommentControlStatement < Linter

--- a/lib/slim_lint/linter/consecutive_control_statements.rb
+++ b/lib/slim_lint/linter/consecutive_control_statements.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Searches for more than an allowed number of consecutive control code
   # statements that could be condensed into a :ruby filter.

--- a/lib/slim_lint/linter/empty_control_statement.rb
+++ b/lib/slim_lint/linter/empty_control_statement.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Searches for control statements with no code.
   class Linter::EmptyControlStatement < Linter

--- a/lib/slim_lint/linter/empty_lines.rb
+++ b/lib/slim_lint/linter/empty_lines.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # This linter checks for two or more consecutive blank lines
   # and for the first blank line in file.

--- a/lib/slim_lint/linter/line_length.rb
+++ b/lib/slim_lint/linter/line_length.rb
@@ -5,7 +5,7 @@ module SlimLint
   class Linter::LineLength < Linter
     include LinterRegistry
 
-    MSG = 'Line is too long. [%d/%d]'.freeze
+    MSG = 'Line is too long. [%d/%d]'
 
     on_start do |_sexp|
       max_length = config['max']

--- a/lib/slim_lint/linter/redundant_div.rb
+++ b/lib/slim_lint/linter/redundant_div.rb
@@ -6,7 +6,7 @@ module SlimLint
   class Linter::RedundantDiv < Linter
     include LinterRegistry
 
-    MESSAGE = '`div` is redundant when %s attribute shortcut is present'.freeze
+    MESSAGE = '`div` is redundant when %s attribute shortcut is present'
 
     on [:html, :tag, 'div',
          [:html, :attrs,

--- a/lib/slim_lint/linter/rubocop.rb
+++ b/lib/slim_lint/linter/rubocop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slim_lint/ruby_extractor'
 require 'slim_lint/ruby_extract_engine'
 require 'rubocop'

--- a/lib/slim_lint/linter/tab.rb
+++ b/lib/slim_lint/linter/tab.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Searches for tab indentation
   class Linter::Tab < Linter
     include LinterRegistry
 
-    MSG = 'Tab detected'.freeze
+    MSG = 'Tab detected'
 
     on_start do |_sexp|
       dummy_node = Struct.new(:line)

--- a/lib/slim_lint/linter/tag_case.rb
+++ b/lib/slim_lint/linter/tag_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Searches for tags with uppercase characters.
   class Linter::TagCase < Linter

--- a/lib/slim_lint/linter/trailing_blank_lines.rb
+++ b/lib/slim_lint/linter/trailing_blank_lines.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # This linter looks for trailing blank lines and a final newline.
   class Linter::TrailingBlankLines < Linter

--- a/lib/slim_lint/linter/trailing_whitespace.rb
+++ b/lib/slim_lint/linter/trailing_whitespace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Checks for trailing whitespace.
   class Linter::TrailingWhitespace < Linter

--- a/lib/slim_lint/linter_registry.rb
+++ b/lib/slim_lint/linter_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   class NoSuchLinter < StandardError; end
 

--- a/lib/slim_lint/linter_selector.rb
+++ b/lib/slim_lint/linter_selector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Chooses the appropriate linters to run given the specified configuration.
   class LinterSelector

--- a/lib/slim_lint/logger.rb
+++ b/lib/slim_lint/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Encapsulates all communication to an output source.
   class Logger

--- a/lib/slim_lint/matcher/anything.rb
+++ b/lib/slim_lint/matcher/anything.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint::Matcher
   # Will match anything, acting as a wildcard.
   class Anything < Base

--- a/lib/slim_lint/matcher/base.rb
+++ b/lib/slim_lint/matcher/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint::Matcher
   # Represents a Sexp pattern implementing complex matching logic.
   #

--- a/lib/slim_lint/matcher/capture.rb
+++ b/lib/slim_lint/matcher/capture.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint::Matcher
   # Wraps a matcher, taking on the behavior of the wrapped matcher but storing
   # the value that matched so it can be referred to later.

--- a/lib/slim_lint/matcher/nothing.rb
+++ b/lib/slim_lint/matcher/nothing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint::Matcher
   # Does not match anything.
   #

--- a/lib/slim_lint/options.rb
+++ b/lib/slim_lint/options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'optparse'
 
 module SlimLint

--- a/lib/slim_lint/rake_task.rb
+++ b/lib/slim_lint/rake_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake'
 require 'rake/tasklib'
 require 'slim_lint/constants'

--- a/lib/slim_lint/report.rb
+++ b/lib/slim_lint/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Contains information about all lints detected during a scan.
   class Report

--- a/lib/slim_lint/reporter.rb
+++ b/lib/slim_lint/reporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Abstract lint reporter. Subclass and override {#display_report} to
   # implement a custom lint reporter.

--- a/lib/slim_lint/reporter/checkstyle_reporter.rb
+++ b/lib/slim_lint/reporter/checkstyle_reporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rexml/document'
 
 module SlimLint

--- a/lib/slim_lint/reporter/default_reporter.rb
+++ b/lib/slim_lint/reporter/default_reporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Outputs lints in a simple format with the filename, line number, and lint
   # message.

--- a/lib/slim_lint/reporter/json_reporter.rb
+++ b/lib/slim_lint/reporter/json_reporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Outputs report as a JSON document.
   class Reporter::JsonReporter < Reporter

--- a/lib/slim_lint/ruby_extract_engine.rb
+++ b/lib/slim_lint/ruby_extract_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Generates a {SlimLint::Sexp} suitable for consumption by the
   # {RubyExtractor}.

--- a/lib/slim_lint/ruby_extractor.rb
+++ b/lib/slim_lint/ruby_extractor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Utility class for extracting Ruby script from a Slim template that can then
   # be linted with a Ruby linter (i.e. is "legal" Ruby).

--- a/lib/slim_lint/ruby_parser.rb
+++ b/lib/slim_lint/ruby_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop'
 require 'rubocop/ast/builder'
 require 'parser/current'

--- a/lib/slim_lint/runner.rb
+++ b/lib/slim_lint/runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Responsible for running the applicable linters against the desired files.
   class Runner

--- a/lib/slim_lint/sexp.rb
+++ b/lib/slim_lint/sexp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Symbolic expression which represents tree-structured data.
   #

--- a/lib/slim_lint/sexp.rb
+++ b/lib/slim_lint/sexp.rb
@@ -80,7 +80,7 @@ module SlimLint
     # @return [String]
     def display(depth = 1) # rubocop:disable Metrics/AbcSize
       indentation = ' ' * 2 * depth
-      output = '['
+      output = '['.dup
 
       each_with_index do |nested_sexp, index|
         output << "\n"

--- a/lib/slim_lint/sexp_visitor.rb
+++ b/lib/slim_lint/sexp_visitor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Provides an interface which when included allows a class to visit nodes in
   # the Sexp of a Slim document.

--- a/lib/slim_lint/utils.rb
+++ b/lib/slim_lint/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SlimLint
   # Miscellaneus collection of helper functions.
   module Utils

--- a/lib/slim_lint/version.rb
+++ b/lib/slim_lint/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module SlimLint
-  VERSION = '0.15.1'.freeze
+  VERSION = '0.15.1'
 end

--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -1,4 +1,6 @@
-$LOAD_PATH << File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH << File.expand_path('lib', __dir__)
 require 'slim_lint/constants'
 require 'slim_lint/version'
 
@@ -20,7 +22,7 @@ Gem::Specification.new do |s|
                        Dir['lib/**/*.rb'] +
                        ['LICENSE.md']
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.add_dependency 'rake', '>= 10', '< 13'
   s.add_dependency 'rubocop', '>= 0.50.0'

--- a/spec/slim_lint/atom_spec.rb
+++ b/spec/slim_lint/atom_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Atom do

--- a/spec/slim_lint/capture_map_spec.rb
+++ b/spec/slim_lint/capture_map_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::CaptureMap do

--- a/spec/slim_lint/cli_spec.rb
+++ b/spec/slim_lint/cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'slim_lint/cli'
 

--- a/spec/slim_lint/configuration_loader_spec.rb
+++ b/spec/slim_lint/configuration_loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::ConfigurationLoader do
@@ -45,7 +47,7 @@ describe SlimLint::ConfigurationLoader do
 
     before do
       # Ensure cache is cleared
-      described_class.instance_variable_set(:@default_config, nil)
+      described_class.instance_variable_set(:@default_configuration, nil)
     end
 
     it 'loads the default config file' do

--- a/spec/slim_lint/configuration_spec.rb
+++ b/spec/slim_lint/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Configuration do

--- a/spec/slim_lint/document_spec.rb
+++ b/spec/slim_lint/document_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Document do

--- a/spec/slim_lint/engine_spec.rb
+++ b/spec/slim_lint/engine_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Engine do

--- a/spec/slim_lint/file_finder_spec.rb
+++ b/spec/slim_lint/file_finder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::FileFinder do

--- a/spec/slim_lint/filters/inject_line_numbers_spec.rb
+++ b/spec/slim_lint/filters/inject_line_numbers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Filters::InjectLineNumbers do

--- a/spec/slim_lint/filters/sexp_converter_spec.rb
+++ b/spec/slim_lint/filters/sexp_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Filters::SexpConverter do

--- a/spec/slim_lint/linter/comment_control_statement_spec.rb
+++ b/spec/slim_lint/linter/comment_control_statement_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::CommentControlStatement do

--- a/spec/slim_lint/linter/consecutive_control_statements_spec.rb
+++ b/spec/slim_lint/linter/consecutive_control_statements_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::ConsecutiveControlStatements do

--- a/spec/slim_lint/linter/empty_control_statement_spec.rb
+++ b/spec/slim_lint/linter/empty_control_statement_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::EmptyControlStatement do

--- a/spec/slim_lint/linter/empty_lines_spec.rb
+++ b/spec/slim_lint/linter/empty_lines_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::EmptyLines do

--- a/spec/slim_lint/linter/line_length_spec.rb
+++ b/spec/slim_lint/linter/line_length_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::LineLength do

--- a/spec/slim_lint/linter/redundant_div_spec.rb
+++ b/spec/slim_lint/linter/redundant_div_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::RedundantDiv do

--- a/spec/slim_lint/linter/rubocop_spec.rb
+++ b/spec/slim_lint/linter/rubocop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::RuboCop do

--- a/spec/slim_lint/linter/tab_spec.rb
+++ b/spec/slim_lint/linter/tab_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::Tab do

--- a/spec/slim_lint/linter/tag_case_spec.rb
+++ b/spec/slim_lint/linter/tag_case_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::TagCase do

--- a/spec/slim_lint/linter/trailing_blank_lines_spec.rb
+++ b/spec/slim_lint/linter/trailing_blank_lines_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::TrailingBlankLines do

--- a/spec/slim_lint/linter/trailing_whitespace_spec.rb
+++ b/spec/slim_lint/linter/trailing_whitespace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter::TrailingWhitespace do

--- a/spec/slim_lint/linter_registry_spec.rb
+++ b/spec/slim_lint/linter_registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::LinterRegistry do

--- a/spec/slim_lint/linter_selector_spec.rb
+++ b/spec/slim_lint/linter_selector_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::LinterSelector do

--- a/spec/slim_lint/linter_spec.rb
+++ b/spec/slim_lint/linter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Linter do

--- a/spec/slim_lint/linter_spec.rb
+++ b/spec/slim_lint/linter_spec.rb
@@ -35,7 +35,7 @@ describe SlimLint::Linter do
         end
       end
 
-      let(:sexp) { [:ruby, "puts 'Hello world'"] }
+      let(:sexp) { [:ruby, "puts 'Hello world'".dup] }
 
       it 'parses the ruby' do
         subject

--- a/spec/slim_lint/logger_spec.rb
+++ b/spec/slim_lint/logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Logger do

--- a/spec/slim_lint/matcher/anything_spec.rb
+++ b/spec/slim_lint/matcher/anything_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Matcher::Anything do

--- a/spec/slim_lint/matcher/base_spec.rb
+++ b/spec/slim_lint/matcher/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Matcher::Base do

--- a/spec/slim_lint/matcher/capture_spec.rb
+++ b/spec/slim_lint/matcher/capture_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Matcher::Capture do

--- a/spec/slim_lint/matcher/nothing_spec.rb
+++ b/spec/slim_lint/matcher/nothing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Matcher::Nothing do

--- a/spec/slim_lint/options_spec.rb
+++ b/spec/slim_lint/options_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'slim_lint/options'

--- a/spec/slim_lint/rake_task_spec.rb
+++ b/spec/slim_lint/rake_task_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'slim_lint/rake_task'
 require 'tempfile'

--- a/spec/slim_lint/reporter/checkstyle_reporter_spec.rb
+++ b/spec/slim_lint/reporter/checkstyle_reporter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Reporter::CheckstyleReporter do

--- a/spec/slim_lint/reporter/default_reporter_spec.rb
+++ b/spec/slim_lint/reporter/default_reporter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Reporter::DefaultReporter do

--- a/spec/slim_lint/reporter/json_reporter_spec.rb
+++ b/spec/slim_lint/reporter/json_reporter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Reporter::JsonReporter do

--- a/spec/slim_lint/reporter_spec.rb
+++ b/spec/slim_lint/reporter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Reporter do

--- a/spec/slim_lint/ruby_extractor_spec.rb
+++ b/spec/slim_lint/ruby_extractor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::RubyExtractor do

--- a/spec/slim_lint/ruby_parser_spec.rb
+++ b/spec/slim_lint/ruby_parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::RubyParser do

--- a/spec/slim_lint/runner_spec.rb
+++ b/spec/slim_lint/runner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Runner do

--- a/spec/slim_lint/sexp_spec.rb
+++ b/spec/slim_lint/sexp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::Sexp do

--- a/spec/slim_lint/sexp_visitor_spec.rb
+++ b/spec/slim_lint/sexp_visitor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SlimLint::SexpVisitor do

--- a/spec/slim_lint/utils_spec.rb
+++ b/spec/slim_lint/utils_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'securerandom'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV['TRAVIS']
   # When running in Travis, report coverage stats to Coveralls.
   require 'coveralls'

--- a/spec/support/directory_spec_helpers.rb
+++ b/spec/support/directory_spec_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 
 # Helpers for creating temporary directories for testing.

--- a/spec/support/isolated_environment.rb
+++ b/spec/support/isolated_environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'tmpdir'
 

--- a/spec/support/matchers/array_excluding.rb
+++ b/spec/support/matchers/array_excluding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Define matcher which determines if an array does NOT include any of a list of
 # items.
 #

--- a/spec/support/matchers/report_lint.rb
+++ b/spec/support/matchers/report_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :report_lint do |options|
   options ||= {}
   count = options[:count]

--- a/spec/support/normalize_indent.rb
+++ b/spec/support/normalize_indent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module IndentNormalizer
   # Strips off excess leading indentation from each line so we can use Heredocs
   # for writing code without having the leading indentation count.

--- a/spec/support/shared_linter_context.rb
+++ b/spec/support/shared_linter_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Makes writing tests for linters a lot DRYer by taking any `slim` variable
 # defined via `let` and normalizing it and running the linter against it.
 shared_context 'linter' do


### PR DESCRIPTION
update rubocop dependency to v0.53.0. and fixed rubocop errors.

It also drop support under ruby 2.2. 
ruby 2.1 has already ended of life. See https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/ .

rubocop already drop supporting under ruby v2.1 since version 0.50.
```
Error: Unsupported Ruby version 2.0 found in `TargetRubyVersion` parameter (in .rubocop.yml). 2.0-compatible analysis was dropped after version 0.50.
Supported versions: 2.1, 2.2, 2.3, 2.4, 2.5
```

disabled Style/MutableConstant cop. while enabling frozen_string_literal pragma, string literal always freezen over ruby 2.3.



