### PR TITLE
DISABLE Style/EmptyLineAfterGuardClause cop by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -58,6 +58,7 @@ linters:
       - Metrics/BlockNesting
       - Metrics/LineLength
       - Naming/FileName
+      - Style/EmptyLineAfterGuardClause
       - Style/FrozenStringLiteralComment
       - Style/IfUnlessModifier
       - Style/Next


### PR DESCRIPTION
This cop has been added in the latest release of Rubocop (0.53)
and is not very well handled in views. It detects false positive
offenses so we should probably disable it by default.