### PR TITLE
Added Linter/FileLength

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -28,6 +28,10 @@ linters:
     enabled: true
     max: 80
 
+  FileLength:
+    enabled: false
+    max: 300
+
   RuboCop:
     enabled: true
     # These cops are incredibly noisy since the Ruby we extract from Slim

--- a/lib/slim_lint/linter/README.md
+++ b/lib/slim_lint/linter/README.md
@@ -5,6 +5,7 @@ Below is a list of linters supported by `slim-lint`, ordered alphabetically.
 * [CommentControlStatement](#commentcontrolstatement)
 * [ConsecutiveControlStatements](#consecutivecontrolstatements)
 * [EmptyControlStatement](#emptycontrolstatement)
+* [FileLength](#filelength)
 * [LineLength](#linelength)
 * [RedundantDiv](#redundantdiv)
 * [RuboCop](#rubocop)
@@ -76,6 +77,23 @@ p Something else
 p Something
 p Something else
 ```
+
+## FileLength
+
+Option | Description
+-------|-----------------------------------------------------------------
+`max`  | Maximum number of lines a single file can have. (default `300`)
+
+You can configure this amount via the `max`
+option on the linter, e.g. by adding the following to your `.slim-lint.yml`:
+
+```yaml
+linters:
+  FileLength:
+    max: 100
+```
+
+Long files are harder to read and usually indicative of complexity.
 
 ## LineLength
 

--- a/lib/slim_lint/linter/file_length.rb
+++ b/lib/slim_lint/linter/file_length.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SlimLint
+  # Checks for file longer than a maximum number of lines.
+  class Linter::FileLength < Linter
+    include LinterRegistry
+
+    MSG = 'File is too long. [%d/%d]'
+
+    on_start do |_sexp|
+      max_length = config['max']
+      dummy_node = Struct.new(:line)
+
+      count = document.source_lines.size
+      if count > max_length
+        report_lint(dummy_node.new(1), format(MSG, count, max_length))
+      end
+    end
+  end
+end

--- a/spec/slim_lint/linter/file_length_spec.rb
+++ b/spec/slim_lint/linter/file_length_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SlimLint::Linter::FileLength do
+  include_context 'linter'
+
+  context 'when a file contains too many lines' do
+    let(:slim) { (0..300).to_a.join("\n") }
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a file does not contain too many lines' do
+    let(:slim) { (0..299).to_a.join("\n") }
+
+    it { should_not report_lint }
+  end
+end


### PR DESCRIPTION
Too long file is not good to read.
It should be separated multiple partial template on general.

So I added Linter/FileLength.

