### PR TITLE
Added control statement spacing linter #81

### DIFF
--- a/lib/slim_lint/linter/control_statement_spacing.rb
+++ b/lib/slim_lint/linter/control_statement_spacing.rb
@@ -17,7 +17,7 @@ module SlimLint
       ruby = captures[:ruby]
       line = line.sub(ruby, 'x')
 
-      next if line =~ /[^ ] [=-] [^ ]/
+      next if line =~ /[^ ] = [^ ]/
       report_lint(sexp, MESSAGE)
     end
   end

--- a/lib/slim_lint/linter/control_statement_spacing.rb
+++ b/lib/slim_lint/linter/control_statement_spacing.rb
@@ -8,13 +8,13 @@ module SlimLint
     MESSAGE = 'Please add a space before and after the `=`'
 
     on [:html, :tag, anything, [],
-         [:slim, :output, anything, capture(:value, anything)]] do |sexp|
+         [:slim, :output, anything, capture(:ruby, anything)]] do |sexp|
 
       # Fetch original Slim code that contains an element with a control statement.
       line = document.source_lines[sexp.line() - 1]
 
       # Remove any Ruby code, because our regexp below must not match inside Ruby.
-      ruby = captures[:value]
+      ruby = captures[:ruby]
       line = line.sub(ruby, 'x')
 
       next if line =~ /[^ ] [=-] [^ ]/

--- a/lib/slim_lint/linter/control_statement_spacing.rb
+++ b/lib/slim_lint/linter/control_statement_spacing.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SlimLint
+  # Checks for missing or superfluous spacing before and after control statements.
+  class Linter::ControlStatementSpacing < Linter
+    include LinterRegistry
+
+    MESSAGE = 'Please add a space before and after the `=`'
+
+    on [:html, :tag, anything, [],
+         [:slim, :output, anything, capture(:value, anything)]] do |sexp|
+
+      # Fetch original Slim code that contains an element with a control statement.
+      line = document.source_lines[sexp.line() - 1]
+
+      # Remove any Ruby code, because our regexp below must not match inside Ruby.
+      ruby = captures[:value]
+      line = line.sub(ruby, 'x')
+
+      next if line =~ /[^ ] [=-] [^ ]/
+      report_lint(sexp, MESSAGE)
+    end
+  end
+end

--- a/spec/slim_lint/linter/control_statement_spacing_spec.rb
+++ b/spec/slim_lint/linter/control_statement_spacing_spec.rb
@@ -152,7 +152,7 @@ describe SlimLint::Linter::ControlStatementSpacing do
   # OK
 
   context 'ruby code that contains an equal sign without spacingh' do
-    let(:slim) { 'div = bad=1' }
+    let(:slim) { 'div = ok=1' }
 
     it { should_not report_lint }
   end

--- a/spec/slim_lint/linter/control_statement_spacing_spec.rb
+++ b/spec/slim_lint/linter/control_statement_spacing_spec.rb
@@ -151,7 +151,7 @@ describe SlimLint::Linter::ControlStatementSpacing do
 
   # OK
 
-  context 'ruby code that contains an equal sign without spacingh' do
+  context 'ruby code that contains an equal sign without spacing' do
     let(:slim) { 'div = ok=1' }
 
     it { should_not report_lint }

--- a/spec/slim_lint/linter/control_statement_spacing_spec.rb
+++ b/spec/slim_lint/linter/control_statement_spacing_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SlimLint::Linter::ControlStatementSpacing do
+  include_context 'linter'
+
+  context 'element missing space before =' do
+    let(:slim) { 'div= bad' }
+
+    it { should report_lint }
+  end
+
+  context 'element missing space after =' do
+    let(:slim) { 'div =bad' }
+
+    it { should report_lint }
+  end
+
+  context 'element missing space around =' do
+    let(:slim) { 'div=bad' }
+
+    it { should report_lint }
+  end
+
+  context 'element too much space before =' do
+    let(:slim) { 'div  =bad' }
+
+    it { should report_lint }
+  end
+
+  context 'element too much space after =' do
+    let(:slim) { 'div=  bad' }
+
+    it { should report_lint }
+  end
+
+  context 'id missing space before =' do
+    let(:slim) { '#submit= bad' }
+
+    it { should report_lint }
+  end
+
+  context 'id missing space after =' do
+    let(:slim) { '#submit =bad' }
+
+    it { should report_lint }
+  end
+
+  context 'id missing space around =' do
+    let(:slim) { '#submit=bad' }
+
+    it { should report_lint }
+  end
+
+  context 'id and class missing space around =' do
+    let(:slim) { '.some-class#submit=bad' }
+
+    it { should report_lint }
+  end
+
+  context 'id too much space before =' do
+    let(:slim) { '#submit  =bad' }
+
+    it { should report_lint }
+  end
+
+  context 'id too much space after =' do
+    let(:slim) { '#submit=  bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class missing space before =' do
+    let(:slim) { '.klass= bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class missing space after =' do
+    let(:slim) { '.klass =bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class missing space around =' do
+    let(:slim) { '.klass=bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class too much space before =' do
+    let(:slim) { '.klass  =bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class too much space after =' do
+    let(:slim) { '.klass=  bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class with hyphen missing space before =' do
+    let(:slim) { '.some-klass= bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class with hyphen missing space after =' do
+    let(:slim) { '.some-klass =bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class with hyphen missing space around =' do
+    let(:slim) { '.some-klass=bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class with hyphen too much space before =' do
+    let(:slim) { '.some-klass  =bad' }
+
+    it { should report_lint }
+  end
+
+  context 'class with hyphen too much space after =' do
+    let(:slim) { '.some-klass=  bad' }
+
+    it { should report_lint }
+  end
+
+  context 'ruby code that contains a properly formatted equal sign' do
+    let(:slim) { 'div =bad = 1' }
+
+    it { should report_lint }
+  end
+
+  context 'ruby code that contains a properly formatted equal sign' do
+    let(:slim) { 'div= bad = 1' }
+
+    it { should report_lint }
+  end
+
+  context 'ruby code that contains a properly formatted equal sign' do
+    let(:slim) { 'div  = bad = 1' }
+
+    it { should report_lint }
+  end
+
+  # OK
+
+  context 'ruby code that contains an equal sign without spacingh' do
+    let(:slim) { 'div = bad=1' }
+
+    it { should_not report_lint }
+  end
+
+  context 'element with hyphen' do
+    let(:slim) { 'div - ok' }
+
+    it { should_not report_lint }
+  end
+
+  context 'control statement without element' do
+    let(:slim) { '= ok' }
+
+    it { should_not report_lint }
+  end
+
+  context 'attribute with equal sign without spacing' do
+    let(:slim) { 'a href=ok' }
+
+    it { should_not report_lint }
+  end
+end


### PR DESCRIPTION
```slim
/ Good
div = 'This is what the official slim documentation uses consistently'

/ Bad
div= 'This is not allowed by the linter.'
div=    'Neither is this'
div         = 'Neither is this'
```

Notice that this error can only occur with `=` but not with `-`

```slim
div - bad

/ Compiles to:
/ <div>- bad</div>
```