### PR TITLE
Fix for linter-specific exclusion

### DIFF
--- a/lib/slim_lint/file_finder.rb
+++ b/lib/slim_lint/file_finder.rb
@@ -72,7 +72,7 @@ module SlimLint
     # @param path [String]
     # @return [String]
     def normalize_path(path)
-      File.expand_path(path.start_with?(".#{File::SEPARATOR}") ? path[2..-1] : path)
+      path.start_with?(".#{File::SEPARATOR}") ? path[2..-1] : path
     end
 
     # Whether the given file should be treated as a Slim file.

--- a/lib/slim_lint/utils.rb
+++ b/lib/slim_lint/utils.rb
@@ -15,8 +15,9 @@ module SlimLint
     # @param file [String]
     # @return [Boolean]
     def any_glob_matches?(globs_or_glob, file)
+      path = File.expand_path(file)
       Array(globs_or_glob).any? do |glob|
-        ::File.fnmatch?(glob, file,
+        ::File.fnmatch?(File.expand_path(glob), path,
                         ::File::FNM_PATHNAME | # Wildcards don't match path separators
                         ::File::FNM_DOTMATCH)  # `*` wildcard matches dotfiles
       end

--- a/spec/slim_lint/file_finder_spec.rb
+++ b/spec/slim_lint/file_finder_spec.rb
@@ -39,7 +39,7 @@ describe SlimLint::FileFinder do
           `touch test.txt`
         end
 
-        it { should == [File.expand_path('test.txt')] }
+        it { should == ['test.txt'] }
 
         context 'and that file is excluded directly' do
           let(:excluded_patterns) { ['test.txt'] }
@@ -62,7 +62,7 @@ describe SlimLint::FileFinder do
     end
 
     context 'when directories are given' do
-      let(:patterns) { [File.expand_path('some-dir')] }
+      let(:patterns) { ['some-dir'] }
 
       context 'and those directories exist' do
         before do
@@ -74,7 +74,7 @@ describe SlimLint::FileFinder do
             `touch some-dir/test.slim`
           end
 
-          it { should == [File.expand_path('some-dir/test.slim')] }
+          it { should == ['some-dir/test.slim'] }
 
           context 'and those Slim files are excluded explicitly' do
             let(:excluded_patterns) { ['some-dir/test.slim'] }
@@ -95,7 +95,7 @@ describe SlimLint::FileFinder do
             `touch some-dir/more-dir/test.slim`
           end
 
-          it { should == [File.expand_path('some-dir/more-dir/test.slim')] }
+          it { should == ['some-dir/more-dir/test.slim'] }
         end
 
         context 'and they contain files with some other extension' do
@@ -121,7 +121,7 @@ describe SlimLint::FileFinder do
             `touch test.slim`
           end
 
-          it { should == [File.expand_path('test.slim')] }
+          it { should == ['test.slim'] }
 
           context 'and those Slim files are excluded explicitly' do
             let(:excluded_patterns) { ['test.slim'] }
@@ -170,7 +170,7 @@ describe SlimLint::FileFinder do
           `touch 'test*.txt' test1.txt`
         end
 
-        it { should == [File.expand_path('test*.txt')] }
+        it { should == ['test*.txt'] }
       end
 
       context 'and files matching the glob pattern exist' do
@@ -179,14 +179,14 @@ describe SlimLint::FileFinder do
         end
 
         it 'includes all matching files' do
-          should == [File.expand_path('test-some-words.txt'),
-                     File.expand_path('test1.txt')]
+          should == ['test-some-words.txt',
+                     'test1.txt']
         end
 
         context 'and a glob pattern excludes a file' do
           let(:excluded_patterns) { ['*some*'] }
 
-          it { should == [File.expand_path('test1.txt')] }
+          it { should == ['test1.txt'] }
         end
       end
     end
@@ -198,7 +198,7 @@ describe SlimLint::FileFinder do
         `touch test.slim`
       end
 
-      it { should == [File.expand_path('test.slim')] }
+      it { should == ['test.slim'] }
     end
 
     context 'when an absolute file path is given' do

--- a/spec/slim_lint/linter_selector_spec.rb
+++ b/spec/slim_lint/linter_selector_spec.rb
@@ -151,6 +151,15 @@ describe SlimLint::LinterSelector do
         end
       end
 
+      context 'and the file matches the exclude pattern and the file is absolute path' do
+        let(:file) { File.expand_path('some-file.slim') }
+        let(:exclude_pattern) { 'some-*.slim' }
+
+        it 'excludes the linter' do
+          subject.map(&:class).should == []
+        end
+      end
+
       context 'and the file matches both the include and exclude patterns' do
         let(:include_pattern) { '**/*-file.slim' }
         let(:exclude_pattern) { '**/some-*.slim' }


### PR DESCRIPTION
Hi, there.
I fixed #77. `LinterSelector` also uses `any_glob_matches?` as `FileFinder` does. So I made `any_glob_matches?` always use absolute path. This changes partially revert ef9a07f5c0.