### PR TITLE
Relax dependency for slim v4.0.0

### DIFF
--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rake', '>= 10', '< 13'
   s.add_dependency 'rubocop', '>= 0.50.0'
-  s.add_dependency 'slim', '~> 3.0'
+  s.add_runtime_dependency 'slim', ['>= 3.0', '< 5.0']
+
   s.add_dependency 'sysexits', '~> 1.1'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Now, slim v4.0.0 is latest.
https://rubygems.org/gems/slim/versions/4.0.0

I want to use slim v4.0.0 via slim-lint.

Gemfile

gem "slim", "4.0.0"
gem "slim-lint", "0.15.1"
$ bundle update

(snip)

Bundler could not find compatible versions for gem "slim":
  In Gemfile:
    slim (= 4.0.0)

    slim-lint (= 0.15.1) was resolved to 0.15.1, which depends on
      slim (~> 3.0)
So I relaxed dependency.
