### PR TITLE
No ControlStatementSpacing warnings on ==> =< #86

### DIFF
--- a/lib/slim_lint/linter/control_statement_spacing.rb
+++ b/lib/slim_lint/linter/control_statement_spacing.rb
@@ -17,7 +17,7 @@ module SlimLint
       ruby = captures[:ruby]
       line = line.sub(ruby, 'x')
 
-      next if line =~ /[^ ] ==? [^ ]/
+      next if line =~ /[^ ] ==?<?>? [^ ]/
       report_lint(sexp, MESSAGE)
     end
   end

--- a/spec/slim_lint/linter/control_statement_spacing_spec.rb
+++ b/spec/slim_lint/linter/control_statement_spacing_spec.rb
@@ -175,6 +175,66 @@ describe SlimLint::Linter::ControlStatementSpacing do
     it { should_not report_lint }
   end
 
+  context 'when leading whitespace (=<) is used' do
+    context 'and it has appropriate spacing' do
+      let(:slim) { 'title =< "Something"' }
+
+      it { should_not report_lint }
+    end
+
+    context 'and it lacks spacing on the left' do
+      let(:slim) { 'title=< "Something"' }
+
+      it { should report_lint }
+    end
+
+    context 'and it lacks spacing on the right' do
+      let(:slim) { 'title =<"Something"' }
+
+      it { should report_lint }
+    end
+  end
+
+  context 'when trailing whitespace (=>) is used' do
+    context 'and it has appropriate spacing' do
+      let(:slim) { 'title => "Something"' }
+
+      it { should_not report_lint }
+    end
+
+    context 'and it lacks spacing on the left' do
+      let(:slim) { 'title=> "Something"' }
+
+      it { should report_lint }
+    end
+
+    context 'and it lacks spacing on the right' do
+      let(:slim) { 'title =>"Something"' }
+
+      it { should report_lint }
+    end
+  end
+
+  context 'when whitespace (=<>) is used' do
+    context 'and it has appropriate spacing' do
+      let(:slim) { 'title =<> "Something"' }
+
+      it { should_not report_lint }
+    end
+
+    context 'and it lacks spacing on the left' do
+      let(:slim) { 'title=<> "Something"' }
+
+      it { should report_lint }
+    end
+
+    context 'and it lacks spacing on the right' do
+      let(:slim) { 'title =<>"Something"' }
+
+      it { should report_lint }
+    end
+  end
+
   context 'when HTML escape disabling (==) is used' do
     context 'and it has appropriate spacing' do
       let(:slim) { 'title == "Something"' }
@@ -190,6 +250,66 @@ describe SlimLint::Linter::ControlStatementSpacing do
 
     context 'and it lacks spacing on the right' do
       let(:slim) { 'title =="Something"' }
+
+      it { should report_lint }
+    end
+  end
+
+  context 'when HTML escape disabling with leading whitespace (==<) is used' do
+    context 'and it has appropriate spacing' do
+      let(:slim) { 'title ==< "Something"' }
+
+      it { should_not report_lint }
+    end
+
+    context 'and it lacks spacing on the left' do
+      let(:slim) { 'title==< "Something"' }
+
+      it { should report_lint }
+    end
+
+    context 'and it lacks spacing on the right' do
+      let(:slim) { 'title ==<"Something"' }
+
+      it { should report_lint }
+    end
+  end
+
+  context 'when HTML escape disabling with trailing whitespace (==>) is used' do
+    context 'and it has appropriate spacing' do
+      let(:slim) { 'title ==> "Something"' }
+
+      it { should_not report_lint }
+    end
+
+    context 'and it lacks spacing on the left' do
+      let(:slim) { 'title==> "Something"' }
+
+      it { should report_lint }
+    end
+
+    context 'and it lacks spacing on the right' do
+      let(:slim) { 'title ==>"Something"' }
+
+      it { should report_lint }
+    end
+  end
+
+  context 'when HTML escape disabling with whitespace (==<>) is used' do
+    context 'and it has appropriate spacing' do
+      let(:slim) { 'title ==<> "Something"' }
+
+      it { should_not report_lint }
+    end
+
+    context 'and it lacks spacing on the left' do
+      let(:slim) { 'title==<> "Something"' }
+
+      it { should report_lint }
+    end
+
+    context 'and it lacks spacing on the right' do
+      let(:slim) { 'title ==<>"Something"' }
 
       it { should report_lint }
     end


### PR DESCRIPTION
This is a proof-of-concept for fixing https://github.com/sds/slim-lint/issues/86

All these need to be supported:

```slim
=
=>
=<
=<>
==
==>
==<
==<>
```

The whole spec is getting a little bit too cluttered. But at least it's explicit (instead of using, say, shared examples).