### PR TITLE
UPDATE EmptyLineAfterGuardClause cop namespace

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -45,6 +45,7 @@ linters:
       - Layout/AlignArray
       - Layout/AlignHash
       - Layout/AlignParameters
+      - Layout/EmptyLineAfterGuardClause
       - Layout/FirstParameterIndentation
       - Layout/IndentArray
       - Layout/IndentationConsistency
@@ -65,7 +66,6 @@ linters:
       - Metrics/BlockNesting
       - Metrics/LineLength
       - Naming/FileName
-      - Style/EmptyLineAfterGuardClause
       - Style/FrozenStringLiteralComment
       - Style/IfUnlessModifier
       - Style/Next


### PR DESCRIPTION
In [v0.56][1] of Rubocop, this cop has been his namespace changed
from `Style` to `Layout`. We should reflect this change in the
`config/default.yml` ignored cops configuration list.

[1]: https://github.com/rubocop-hq/rubocop/releases/tag/v0.56.0