### PR TITLE
DISABLE Layout/InitialIndentation cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -49,6 +49,7 @@ linters:
       - Layout/IndentArray
       - Layout/IndentationConsistency
       - Layout/IndentationWidth
+      - Layout/InitialIndentation
       - Layout/MultilineArrayBraceLayout
       - Layout/MultilineAssignmentLayout
       - Layout/MultilineHashBraceLayout


### PR DESCRIPTION
The [Layout/InitialIndentation][1] cop doesn't play nicely with `slim` views.
We should disable it by default.

[1]: https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/layout/initial_indentation.rb