### PR TITLE
Add missing linters to documentation

### DIFF
--- a/lib/slim_lint/linter/README.md
+++ b/lib/slim_lint/linter/README.md
@@ -4,13 +4,16 @@ Below is a list of linters supported by `slim-lint`, ordered alphabetically.
 
 * [CommentControlStatement](#commentcontrolstatement)
 * [ConsecutiveControlStatements](#consecutivecontrolstatements)
+* [ControlStatementSpacing](#controlstatementspacing)
 * [EmptyControlStatement](#emptycontrolstatement)
+* [EmptyLines](#emptylines)
 * [FileLength](#filelength)
 * [LineLength](#linelength)
 * [RedundantDiv](#redundantdiv)
 * [RuboCop](#rubocop)
 * [Tab](#tab)
 * [TagCase](#tagcase)
+* [TrailingBlankLines](#trailingblanklines)
 * [TrailingWhitespace](#trailingwhitespace)
 
 ## CommentControlStatement
@@ -61,6 +64,20 @@ ruby:
 Large blocks of code in templates make them difficult to read and are usually
 a smell. It is best to extract these into separate helpers whenever possible.
 
+## ControlStatementSpacing
+
+Reports missing or superfluous spacing before and after control statements
+
+**Bad**
+```slim
+div= some_code
+```
+
+**Good**
+```slim
+div = some_code
+```
+
 ## EmptyControlStatement
 
 Reports control statements with no code.
@@ -75,6 +92,25 @@ p Something else
 **Good**
 ```slim
 p Something
+p Something else
+```
+
+## EmptyLines
+
+Reports two or more consecutive blank lin
+
+**Bad**
+```slim
+p Something
+
+
+p Something else
+```
+
+**Good**
+```slim
+p Something
+
 p Something else
 ```
 
@@ -204,6 +240,10 @@ While the HTML standard does not require lowercase tag names, they are a
 _de facto_ standard and are used in almost all documentation and specifications
 available online. However, lowercase tags are required for XHTML documents, so
 using them consistently results in more portable code.
+
+## TrailingBlankLines
+
+Reports trailing blank lines.
 
 ## TrailingWhitespace
 


### PR DESCRIPTION
It would be best documentation generation to be automated (like in Rubocop) but for now I've just added the missing linters manually