### PR TITLE
Sort default linters in alphabetical order

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -11,12 +11,12 @@ linters:
   CommentControlStatement:
     enabled: true
 
-  ControlStatementSpacing:
-    enabled: true
-
   ConsecutiveControlStatements:
     enabled: true
     max_consecutive: 2
+
+  ControlStatementSpacing:
+    enabled: true
 
   EmptyControlStatement:
     enabled: true
@@ -24,16 +24,16 @@ linters:
   EmptyLines:
     enabled: true
 
-  RedundantDiv:
-    enabled: true
+  FileLength:
+    enabled: false
+    max: 300
 
   LineLength:
     enabled: true
     max: 80
 
-  FileLength:
-    enabled: false
-    max: 300
+  RedundantDiv:
+    enabled: true
 
   RuboCop:
     enabled: true


### PR DESCRIPTION
The [Linters Documentation](https://github.com/sds/slim-lint/blob/master/lib/slim_lint/linter/README.md#linters) has a list of linters ordered alphabetically.

This pull request sorts the linters in the [default configuration file](https://github.com/sds/slim-lint/blob/master/config/default.yml) to match the same order.