### PR TITLE
Disable Layout/AlignArguments cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -42,6 +42,7 @@ linters:
     # WARNING: If you define this list in your own .slim-lint.yml file, you'll
     # be overriding the list defined here.
     ignored_cops:
+      - Layout/AlignArguments
       - Layout/AlignArray
       - Layout/AlignHash
       - Layout/AlignParameters


### PR DESCRIPTION
This cop produces false positives in slim templates as for Layout/AlignParameters and therefore should be disabled by default