### PR TITLE
Renamed cops - Rubocop 0.77 compat

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 AllCops:
   TargetRubyVersion: 2.4
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Exclude:
     - 'lib/slim_lint/filters/**/*.rb'
     - 'lib/slim_lint/linter/**/*.rb'

--- a/config/default.yml
+++ b/config/default.yml
@@ -42,12 +42,12 @@ linters:
     # WARNING: If you define this list in your own .slim-lint.yml file, you'll
     # be overriding the list defined here.
     ignored_cops:
-      - Layout/AlignArguments
-      - Layout/AlignArray
-      - Layout/AlignHash
       - Layout/AlignParameters
+      - Layout/ArgumentAlignment
+      - Layout/ArrayAlignment
       - Layout/EmptyLineAfterGuardClause
       - Layout/FirstParameterIndentation
+      - Layout/HashAlignment
       - Layout/IndentArray
       - Layout/IndentationConsistency
       - Layout/IndentationWidth
@@ -60,6 +60,7 @@ linters:
       - Layout/MultilineMethodDefinitionBraceLayout
       - Layout/MultilineOperationIndentation
       - Layout/TrailingBlankLines
+      - Layout/TrailingEmptyLines
       - Layout/TrailingWhitespace
       - Lint/BlockAlignment
       - Lint/EndAlignment


### PR DESCRIPTION
The renames are mentioned in https://github.com/rubocop-hq/rubocop/issues/7077

I'm not sure how to go about making this compatible with both Rubocop < 0.77 and >= 0.77