### PR TITLE
Set minimum RuboCop version to 0.77.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 AllCops:
   TargetRubyVersion: 2.4
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Exclude:
     - 'lib/slim_lint/filters/**/*.rb'
     - 'lib/slim_lint/linter/**/*.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 
 before_script:
   - git config --local user.email "travis@travis.ci"

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ gem 'overcommit', '0.51.0'
 gem 'rake'
 
 # Pin tool versions (which are executed by Overcommit) for Travis builds
-gem 'rubocop', '0.68.1'
+gem 'rubocop', '0.77.0'
 
 gem 'coveralls', require: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -42,13 +42,14 @@ linters:
     # WARNING: If you define this list in your own .slim-lint.yml file, you'll
     # be overriding the list defined here.
     ignored_cops:
-      - Layout/AlignArguments
-      - Layout/AlignArray
-      - Layout/AlignHash
-      - Layout/AlignParameters
+      - Layout/ArgumentAlignment
+      - Layout/ArrayAlignment
+      - Layout/BlockAlignment
       - Layout/EmptyLineAfterGuardClause
+      - Layout/EndAlignment
+      - Layout/FirstArrayElementIndentation
       - Layout/FirstParameterIndentation
-      - Layout/IndentArray
+      - Layout/HashAlignment
       - Layout/IndentationConsistency
       - Layout/IndentationWidth
       - Layout/InitialIndentation
@@ -59,10 +60,9 @@ linters:
       - Layout/MultilineMethodCallIndentation
       - Layout/MultilineMethodDefinitionBraceLayout
       - Layout/MultilineOperationIndentation
-      - Layout/TrailingBlankLines
+      - Layout/ParameterAlignment
+      - Layout/TrailingEmptyLines
       - Layout/TrailingWhitespace
-      - Lint/BlockAlignment
-      - Lint/EndAlignment
       - Lint/Void
       - Metrics/BlockLength
       - Metrics/BlockNesting

--- a/lib/slim_lint/file_finder.rb
+++ b/lib/slim_lint/file_finder.rb
@@ -38,7 +38,7 @@ module SlimLint
     #
     # @param patterns [Array<String>]
     # @return [Array<String>]
-    def extract_files_from(patterns) # rubocop:disable MethodLength
+    def extract_files_from(patterns) # rubocop:disable Metrics/MethodLength
       files = []
 
       patterns.each do |pattern|

--- a/lib/slim_lint/linter/control_statement_spacing.rb
+++ b/lib/slim_lint/linter/control_statement_spacing.rb
@@ -9,7 +9,6 @@ module SlimLint
 
     on [:html, :tag, anything, [],
          [:slim, :output, anything, capture(:ruby, anything)]] do |sexp|
-
       # Fetch original Slim code that contains an element with a control statement.
       line = document.source_lines[sexp.line() - 1]
 

--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4.0'
 
-  s.add_dependency 'rubocop', '>= 0.50.0'
+  s.add_dependency 'rubocop', '>= 0.77.0'
   s.add_runtime_dependency 'slim', ['>= 3.0', '< 5.0']
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Fix #107

A little bit more invasive of #108, but a lot of cops changed their name so, you see...