### PR TITLE
RuboCop 0.78.0 compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ Layout/ArrayAlignment:
 Layout/DotPosition:
   EnforcedStyle: leading
 
+Layout/LineLength:
+  Max: 100
+
 Layout/MultilineOperationIndentation:
   Enabled: false
 
@@ -26,9 +29,6 @@ Lint/Void:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
-
-Metrics/LineLength:
-  Max: 100
 
 Metrics/MethodLength:
   Max: 20

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.0
 
 before_script:
   - git config --local user.email "travis@travis.ci"

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,12 @@ source 'https://rubygems.org'
 gemspec
 
 # Run all pre-commit hooks via Overcommit during CI runs
-gem 'overcommit', '0.51.0'
+gem 'overcommit', '0.52.0'
 
 # Needed for Rake integration tests
 gem 'rake'
 
 # Pin tool versions (which are executed by Overcommit) for Travis builds
-gem 'rubocop', '0.77.0'
+gem 'rubocop', '0.78.0'
 
 gem 'coveralls', require: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -53,6 +53,7 @@ linters:
       - Layout/IndentationConsistency
       - Layout/IndentationWidth
       - Layout/InitialIndentation
+      - Layout/LineLength
       - Layout/MultilineArrayBraceLayout
       - Layout/MultilineAssignmentLayout
       - Layout/MultilineHashBraceLayout
@@ -66,7 +67,6 @@ linters:
       - Lint/Void
       - Metrics/BlockLength
       - Metrics/BlockNesting
-      - Metrics/LineLength
       - Naming/FileName
       - Style/FrozenStringLiteralComment
       - Style/IfUnlessModifier

--- a/lib/slim_lint.rb
+++ b/lib/slim_lint.rb
@@ -19,7 +19,7 @@ require 'slim_lint/logger'
 require 'slim_lint/version'
 
 # Load all filters (required by SlimLint::Engine)
-Dir[File.expand_path('slim_lint/filters/*.rb', File.dirname(__FILE__))].each do |file|
+Dir[File.expand_path('slim_lint/filters/*.rb', File.dirname(__FILE__))].sort.each do |file|
   require file
 end
 
@@ -37,16 +37,16 @@ require 'slim_lint/runner'
 
 # Load all matchers
 require 'slim_lint/matcher/base'
-Dir[File.expand_path('slim_lint/matcher/*.rb', File.dirname(__FILE__))].each do |file|
+Dir[File.expand_path('slim_lint/matcher/*.rb', File.dirname(__FILE__))].sort.each do |file|
   require file
 end
 
 # Load all linters
-Dir[File.expand_path('slim_lint/linter/*.rb', File.dirname(__FILE__))].each do |file|
+Dir[File.expand_path('slim_lint/linter/*.rb', File.dirname(__FILE__))].sort.each do |file|
   require file
 end
 
 # Load all reporters
-Dir[File.expand_path('slim_lint/reporter/*.rb', File.dirname(__FILE__))].each do |file|
+Dir[File.expand_path('slim_lint/reporter/*.rb', File.dirname(__FILE__))].sort.each do |file|
   require file
 end

--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4.0'
 
-  s.add_dependency 'rubocop', '>= 0.77.0'
+  s.add_dependency 'rubocop', '>= 0.78.0'
   s.add_runtime_dependency 'slim', ['>= 3.0', '< 5.0']
 
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/slim_lint/linter/comment_control_statement_spec.rb
+++ b/spec/slim_lint/linter/comment_control_statement_spec.rb
@@ -23,9 +23,9 @@ describe SlimLint::Linter::CommentControlStatement do
 
   context 'when a control statement contains a RuboCop directive' do
     let(:slim) { <<-SLIM }
-      -# rubocop:disable Metrics/LineLength
+      -# rubocop:disable Layout/LineLength
       - some_code
-      -# rubocop:enable Metrics/LineLength
+      -# rubocop:enable Layout/LineLength
     SLIM
 
     it { should_not report_lint }

--- a/spec/slim_lint/linter/rubocop_spec.rb
+++ b/spec/slim_lint/linter/rubocop_spec.rb
@@ -45,7 +45,7 @@ describe SlimLint::Linter::RuboCop do
     end
 
     context 'and the offence is from an ignored cop' do
-      let(:cop_name) { 'Metrics/LineLength' }
+      let(:cop_name) { 'Layout/LineLength' }
       it { should_not report_lint }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ end
 require 'slim_lint'
 require 'rspec/its'
 
-Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
+Dir[File.dirname(__FILE__) + '/support/**/*.rb'].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.include DirectorySpecHelpers


### PR DESCRIPTION
Also bumps the minimum required RuboCop version to 0.78.0, this will not be too painful since we have recently moved to 0.77.0