### PR TITLE
Remove Style/IdenticalConditionalBranches from default cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -69,7 +69,7 @@ linters:
       - Metrics/BlockNesting
       - Naming/FileName
       - Style/FrozenStringLiteralComment
-      - Style/IdenticalConditionalBranches      
+      - Style/IdenticalConditionalBranches
       - Style/IfUnlessModifier
       - Style/Next
       - Style/WhileUntilModifier

--- a/config/default.yml
+++ b/config/default.yml
@@ -69,6 +69,7 @@ linters:
       - Metrics/BlockNesting
       - Naming/FileName
       - Style/FrozenStringLiteralComment
+      - Style/IdenticalConditionalBranches      
       - Style/IfUnlessModifier
       - Style/Next
       - Style/WhileUntilModifier


### PR DESCRIPTION
Do not run the  Style/IdenticalConditionalBranches cop by default since it causes false-positives as reported in #99