### PR TITLE
Linter for embedded engines

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -18,6 +18,10 @@ linters:
   ControlStatementSpacing:
     enabled: true
 
+  EmbeddedEngines:
+    enabled: true
+    forbidden_engines: []
+
   EmptyControlStatement:
     enabled: true
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -19,7 +19,7 @@ linters:
     enabled: true
 
   EmbeddedEngines:
-    enabled: true
+    enabled: false
     forbidden_engines: []
 
   EmptyControlStatement:

--- a/lib/slim_lint/linter/README.md
+++ b/lib/slim_lint/linter/README.md
@@ -5,6 +5,7 @@ Below is a list of linters supported by `slim-lint`, ordered alphabetically.
 * [CommentControlStatement](#commentcontrolstatement)
 * [ConsecutiveControlStatements](#consecutivecontrolstatements)
 * [ControlStatementSpacing](#controlstatementspacing)
+* [EmbeddedEngines](#embeddedengines)
 * [EmptyControlStatement](#emptycontrolstatement)
 * [EmptyLines](#emptylines)
 * [FileLength](#filelength)
@@ -76,6 +77,29 @@ div= some_code
 **Good**
 ```slim
 div = some_code
+```
+
+## EmbeddedEngines
+
+Reports forbidden [embedded engines](https://github.com/slim-template/slim#embedded-engines-markdown-) if listed.
+
+Option | Description
+-------|-----------------------------------------------------------------
+`forbidden_engines`  | List of forbidden embedded engines. (default [])
+
+```yaml
+linters:
+  EmbeddedEngines:
+    forbidden_engines:
+      - javascript
+```
+
+**Bad for above configuration**
+```slim
+p Something
+
+javascript:
+  alert('foo')
 ```
 
 ## EmptyControlStatement

--- a/lib/slim_lint/linter/README.md
+++ b/lib/slim_lint/linter/README.md
@@ -90,6 +90,7 @@ Option | Description
 ```yaml
 linters:
   EmbeddedEngines:
+    enabled: true
     forbidden_engines:
       - javascript
 ```

--- a/lib/slim_lint/linter/embedded_engines.rb
+++ b/lib/slim_lint/linter/embedded_engines.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SlimLint
+  # Checks for forbidden embedded engines.
+  class Linter::EmbeddedEngines < Linter
+    include LinterRegistry
+
+    MESSAGE = 'Forbidden embedded engine `%s` found'
+
+    on_start do |_sexp|
+      forbidden_engines = config['forbidden_engines']
+      dummy_node = Struct.new(:line)
+      document.source_lines.each_with_index do |line, index|
+        forbidden_engines.each do |forbidden_engine|
+          next unless line =~ /^#{forbidden_engine}.*:\s*$/
+
+          report_lint(dummy_node.new(index + 1), MESSAGE % forbidden_engine)
+        end
+      end
+    end
+  end
+end

--- a/spec/slim_lint/linter/embedded_engines_spec.rb
+++ b/spec/slim_lint/linter/embedded_engines_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SlimLint::Linter::EmbeddedEngines do
+  include_context 'linter'
+
+  context 'when a file contains forbidden embedded engine' do
+    context 'default' do
+      let(:slim) { <<-SLIM }
+        h1 heading
+
+        javascript:
+          alert('foo')
+
+        css:
+          h1 {
+            font-size: 10px;
+          }
+      SLIM
+
+      it { should_not report_lint }
+    end
+
+    context 'add forbidden engines' do
+      let(:config) do
+        {
+          'enabled' => true, 'include' => [], 'exclude': [],
+          'forbidden_engines' => %w[javascript css],
+        }
+      end
+
+      let(:slim) { <<-SLIM }
+        h1 heading
+
+        javascript:
+          alert('foo')
+
+        css:
+          h1 {
+            font-size: 10px;
+          }
+      SLIM
+
+      it { should report_lint line: 3 }
+      it { should report_lint line: 6 }
+    end
+  end
+end

--- a/spec/slim_lint/linter/embedded_engines_spec.rb
+++ b/spec/slim_lint/linter/embedded_engines_spec.rb
@@ -5,45 +5,40 @@ require 'spec_helper'
 describe SlimLint::Linter::EmbeddedEngines do
   include_context 'linter'
 
-  context 'when a file contains forbidden embedded engine' do
-    context 'default' do
-      let(:slim) { <<-SLIM }
-        h1 heading
+  context 'default configuration' do
+    let(:slim) { <<-SLIM }
+      h1 heading
 
-        javascript:
-          alert('foo')
+      javascript:
+        alert('foo')
 
-        css:
-          h1 {
-            font-size: 10px;
-          }
-      SLIM
-
-      it { should_not report_lint }
-    end
-
-    context 'add forbidden engines' do
-      let(:config) do
-        {
-          'enabled' => true, 'include' => [], 'exclude': [],
-          'forbidden_engines' => %w[javascript css],
+      css:
+        h1 {
+          font-size: 10px;
         }
-      end
+    SLIM
 
-      let(:slim) { <<-SLIM }
-        h1 heading
+    it { should_not report_lint }
+  end
 
-        javascript:
-          alert('foo')
-
-        css:
-          h1 {
-            font-size: 10px;
-          }
-      SLIM
-
-      it { should report_lint line: 3 }
-      it { should report_lint line: 6 }
+  context 'when a file contains forbidden embedded engine' do
+    let(:config) do
+      { 'forbidden_engines' => %w[javascript css] }
     end
+
+    let(:slim) { <<-SLIM }
+      h1 heading
+
+      javascript:
+        alert('foo')
+
+      css:
+        h1 {
+          font-size: 10px;
+        }
+    SLIM
+
+    it { should report_lint line: 3 }
+    it { should report_lint line: 6 }
   end
 end


### PR DESCRIPTION
Sometimes, I want to forbid the use of [embedded engines in slim](https://github.com/slim-template/slim#embedded-engines-markdown-).
For instance, inline CSS or JavaScript may cause lower performance and code readability.

I've added a linter to report **forbidden** embedded engines.
This `EmbeddedEngines` linter will forbid nothing to default.

Maybe my code and this linter name is not quite right.
So, any advice or suggestion would be appreciated!

- default: report nothing

```slim
h1 heading

javascript:
  alert('foo')

css:
  h1 {
    font-size: 10px;
  }
```

- add forbidden engines

```yaml
linters:
  EmbeddedEngines:
    enabled: true
    forbidden_engines:
      - javascript
      - css
```

```slim
h1 heading

javascript:
  alert('foo')

css:
  h1 {
    font-size: 10px;
  }
```

works like this
```sh
$ slim-lint sample.slim
sample.slim:3 [W] EmbeddedEngines: Forbidden embedded engine `javascript` found
sample.slim:6 [W] EmbeddedEngines: Forbidden embedded engine `css` found
```