### PR TITLE
Add `linter` field to JSON reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 /coverage
 /pkg
+.ruby-version

--- a/lib/slim_lint/reporter/json_reporter.rb
+++ b/lib/slim_lint/reporter/json_reporter.rb
@@ -45,6 +45,7 @@ module SlimLint
         location: {
           line: offense.line,
         },
+        linter: offense.linter&.name,
       }
     end
   end

--- a/spec/slim_lint/reporter/json_reporter_spec.rb
+++ b/spec/slim_lint/reporter/json_reporter_spec.rb
@@ -48,16 +48,28 @@ describe SlimLint::Reporter::JsonReporter do
       let(:lines)        { [502, 724] }
       let(:descriptions) { ['Description of lint 1', 'Description of lint 2'] }
       let(:severities)   { [:warning, :error] }
+      let(:linters) { [double(name: 'SomeLinter'), nil] }
 
       let(:lints) do
         filenames.each_with_index.map do |filename, index|
-          SlimLint::Lint.new(nil, filename, lines[index], descriptions[index], severities[index])
+          SlimLint::Lint.new(linters[index], filename, lines[index], descriptions[index],
+                             severities[index])
         end
       end
 
       it 'list of files contains files with offenses' do
         subject
         output['files'].map { |f| f['path'] }.sort.should eq filenames.sort
+      end
+
+      it 'list of offenses' do
+        subject
+        output['files'].sort_by { |f| f['path'] }.map { |f| f['offenses'] }.should eq [
+          [{ 'linter' => nil, 'location' => { 'line' => 724 },
+             'message' => 'Description of lint 2', 'severity' => 'error' }],
+          [{ 'linter' => 'SomeLinter', 'location' => { 'line' => 502 },
+             'message' => 'Description of lint 1', 'severity' => 'warning' }],
+        ]
       end
 
       it_behaves_like 'output format specification'


### PR DESCRIPTION
Hello, thanks for this nice gem!

This change adds a new field `linter` into `offenses` with the JSON reporter.

The default reporter outputs linter names like `foo.slim:1 [W] CommentControlStatement: Slim code comments ...`.
But the JSON reporter does not output linter names. I’d like to extract linter IDs from JSON output, and I think it so useful if the JSON reporter also would output linter names.

I’d appreciate if you could give me feedback. Thank you.