### PR TITLE
Add emacs style reporter

### DIFF
--- a/lib/slim_lint/reporter/emacs_reporter.rb
+++ b/lib/slim_lint/reporter/emacs_reporter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module SlimLint
+  # Outputs lints in format: {filename}:{line}:{column}: {kind}: {message}.
+  class Reporter::EmacsReporter < Reporter
+    def display_report(report)
+      sorted_lints = report.lints.sort_by { |l| [l.filename, l.line] }
+
+      sorted_lints.each do |lint|
+        print_location(lint)
+        print_type(lint)
+        print_message(lint)
+      end
+    end
+
+    private
+
+    def print_location(lint)
+      log.info lint.filename, false
+      log.log ':', false
+      log.bold lint.line, false
+      log.log ':', false
+      # TODO: change 1 to column number when linter will have this info.
+      log.bold 1, false
+      log.log ':', false
+    end
+
+    def print_type(lint)
+      if lint.error?
+        log.error ' E: ', false
+      else
+        log.warning ' W: ', false
+      end
+    end
+
+    def print_message(lint)
+      if lint.linter
+        log.success("#{lint.linter.name}: ", false)
+      end
+
+      log.log lint.message
+    end
+  end
+end

--- a/spec/slim_lint/reporter/emacs_reporter_spec.rb
+++ b/spec/slim_lint/reporter/emacs_reporter_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SlimLint::Reporter::EmacsReporter do
+  describe '#display_report' do
+    let(:io) { StringIO.new }
+    let(:output) { io.string }
+    let(:logger) { SlimLint::Logger.new(io) }
+    let(:report) { SlimLint::Report.new(lints, []) }
+    let(:reporter) { described_class.new(logger) }
+
+    subject { reporter.display_report(report) }
+
+    context 'when there are no lints' do
+      let(:lints) { [] }
+
+      it 'prints nothing' do
+        subject
+        output.should be_empty
+      end
+    end
+
+    context 'when there are lints' do
+      let(:filenames)    { ['some-filename.slim', 'other-filename.slim'] }
+      let(:lines)        { [502, 724] }
+      let(:descriptions) { ['Description of lint 1', 'Description of lint 2'] }
+      let(:severities)   { [:warning] * 2 }
+      let(:linter)       { double(name: 'SomeLinter') }
+
+      let(:lints) do
+        filenames.each_with_index.map do |filename, index|
+          SlimLint::Lint.new(linter, filename, lines[index], descriptions[index], severities[index])
+        end
+      end
+
+      it 'prints each lint on its own line' do
+        subject
+        output.count("\n").should == 2
+      end
+
+      it 'prints a trailing newline' do
+        subject
+        output[-1].should == "\n"
+      end
+
+      it 'prints the filename for each lint' do
+        subject
+        filenames.each do |filename|
+          output.scan(/#{filename}/).count.should == 1
+        end
+      end
+
+      it 'prints the line number for each lint' do
+        subject
+        lines.each do |line|
+          output.scan(/#{line}/).count.should == 1
+        end
+      end
+
+      it 'prints the description for each lint' do
+        subject
+        descriptions.each do |description|
+          output.scan(/#{description}/).count.should == 1
+        end
+      end
+
+      context 'when lints are warnings' do
+        it 'prints the warning severity code on each line' do
+          subject
+          output.split("\n").each do |line|
+            line.scan(/W:/).count.should == 1
+          end
+        end
+      end
+
+      context 'when lints are errors' do
+        let(:severities) { [:error] * 2 }
+
+        it 'prints the error severity code on each line' do
+          subject
+          output.split("\n").each do |line|
+            line.scan(/E:/).count.should == 1
+          end
+        end
+      end
+
+      context 'when lint has no associated linter' do
+        let(:linter) { nil }
+
+        it 'prints the description for each lint' do
+          subject
+          descriptions.each do |description|
+            output.scan(/#{description}/).count.should == 1
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Results in
```
me.slim:1:1: W: LineLength: Line is too long. [99/80]
```
and follows this pattern
```
{filename}:{line}:{column}: {kind}: {message}
```

Format is named after `--format emacs` in Rubocop.