### PR TITLE
Disable RuboCop's Layout/FirstArgumentIndentation

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -51,6 +51,7 @@ linters:
       - Layout/BlockAlignment
       - Layout/EmptyLineAfterGuardClause
       - Layout/EndAlignment
+      - Layout/FirstArgumentIndentation
       - Layout/FirstArrayElementIndentation
       - Layout/FirstParameterIndentation
       - Layout/HashAlignment


### PR DESCRIPTION
This is also affected by the incomplete indentation information. Perhaps this was meant instead of FirstParameterIndentation, because that one is for method definitions, and it's unlikely that there are method definitions in Slim templates.

Fixes #122 