### PR TITLE
Ignore cop Layout/LineEndStringConcatenationIndentation

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -58,6 +58,7 @@ linters:
       - Layout/IndentationConsistency
       - Layout/IndentationWidth
       - Layout/InitialIndentation
+      - Layout/LineEndStringConcatenationIndentation
       - Layout/LineLength
       - Layout/MultilineArrayBraceLayout
       - Layout/MultilineAssignmentLayout


### PR DESCRIPTION
Hi *!

This cop was added [recently](https://github.com/jonas054/rubocop/commit/ac1c62f98b2dc01c974c0ed9298a980592d76277) and since the ruby extracted from slim templates does not maintain the original format, it should be ignored by default.

I spent some trying to fix the alignment for our slim pages before realising that was the problem, we added it locally to our ignore list but I think it is worth to add it also to the default ignored cops of the project since someone else may have the same problem, so I hope this is ok.

Cheers!