### PR TITLE
Ignore RuboCop: Layout/FirstHashElementIndentation

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -53,6 +53,7 @@ linters:
       - Layout/EndAlignment
       - Layout/FirstArgumentIndentation
       - Layout/FirstArrayElementIndentation
+      - Layout/FirstHashElementIndentation
       - Layout/FirstParameterIndentation
       - Layout/HashAlignment
       - Layout/IndentationConsistency


### PR DESCRIPTION
Hello, thank you all for your work on this project! It's been great to work with!

I propose to add Rubocop's Layout/FirstHashElementIndentation to the default list of ignored cops.

When using multiline hashes in a slim file, this cop will raise offenses that cannot be solved.

Code that would offend:
```
= f.input :account_id, \
  input_html: { \
    include_blank: true,    ## here
    data: { \
      action: 'change->account-filter#submit',    ## also here
    },
  }
```

I'm not super comfortable with the code I'm working with and whether it's written in the 'right way', so I'm very interested in alternative solutions if I'm doing it the 'wrong way'!

Thanks again for all your work!