### PR TITLE
Ignore RuboCop: Layout/ClosingParenthesisIndentation

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -49,6 +49,7 @@ linters:
       - Layout/ArgumentAlignment
       - Layout/ArrayAlignment
       - Layout/BlockAlignment
+      - Layout/ClosingParenthesisIndentation
       - Layout/EmptyLineAfterGuardClause
       - Layout/EndAlignment
       - Layout/FirstArgumentIndentation


### PR DESCRIPTION
Hello, thanks again for your work on this project! It's still been great to work with!

I propose to also add Rubocop's Layout/ClosingParenthesisIndentation to the default list of ignored cops.

When using multiline methods in a slim file, this cop will raise offenses that cannot be solved in some cases.

Code that would offend:
```
= image_tag(authorized_blob_path(blob, \
    variation_key: 'some_really_long_variation_key',
  ),
) # This one will never be aligned correctly according to RuboCop
```

Thanks again for all your work!