### PR TITLE
Fix `CommentControlStatement` to not report Rails' Template Dependency directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slim-Lint Changelog
 
+## master (unreleased)
+
+* Fix `CommentControlStatement` to not report `Template Dependency:` directives
+
 ## 0.22.0
 
 * Disable RuboCop `Layout/FirstArgumentIndentation`

--- a/lib/slim_lint/linter/comment_control_statement.rb
+++ b/lib/slim_lint/linter/comment_control_statement.rb
@@ -12,6 +12,7 @@ module SlimLint
       comment = code[/\A\s*#(.*\z)/, 1]
 
       next if comment =~ /^\s*rubocop:\w+/
+      next if comment =~ /^\s*Template Dependency:/
 
       report_lint(sexp,
                   "Slim code comments (`/#{comment}`) are preferred over " \

--- a/spec/slim_lint/linter/comment_control_statement_spec.rb
+++ b/spec/slim_lint/linter/comment_control_statement_spec.rb
@@ -30,4 +30,13 @@ describe SlimLint::Linter::CommentControlStatement do
 
     it { should_not report_lint }
   end
+
+  context 'when a control statement contains a Rails Template Dependency directive' do
+    let(:slim) { <<-SLIM }
+      -# Template Dependency: some/partial
+      = render some_helper_method_that_returns_a_partial_name
+    SLIM
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
```
- # Template Dependency: something/foo
```

should not trigger the CommentControlStatement linter, just as `rubocop:` directives don't.