### PR TITLE
Reset the disabled_lines ivar for each new file

### DIFF
--- a/lib/slim_lint/linter.rb
+++ b/lib/slim_lint/linter.rb
@@ -29,6 +29,7 @@ module SlimLint
     def run(document)
       @document = document
       @lints = []
+      @disabled_lines = nil
       trigger_pattern_callbacks(document.sexp)
       @lints
     end

--- a/spec/slim_lint/config_comment_spec.rb
+++ b/spec/slim_lint/config_comment_spec.rb
@@ -3,11 +3,11 @@
 require 'spec_helper'
 
 describe 'Config comments' do
-  include_context 'linter'
+  context 'single file' do
+    include_context 'linter'
 
-  let(:described_class) { SlimLint::Linter::TagCase }
+    let(:described_class) { SlimLint::Linter::TagCase }
 
-  context '' do
     let(:slim) { <<-SLIM }
       IMG src="images/cat.gif"
 
@@ -21,5 +21,47 @@ describe 'Config comments' do
     it { should report_lint line: 1 }
     it { should_not report_lint line: 4 }
     it { should report_lint line: 7 }
+  end
+
+  context 'multiple files' do
+    # We can't use the 'linter' shared context here because it assumes
+    # that the linter is being run on a single file.
+
+    let(:described_class) { SlimLint::Linter::TagCase }
+
+    let(:config) do
+      SlimLint::ConfigurationLoader.default_configuration
+                                   .for_linter(described_class)
+    end
+
+    subject { described_class.new(config) }
+
+    let(:first_file) { <<-SLIM }
+      IMG src="images/cat.gif"
+    SLIM
+
+    let(:second_file) { <<-SLIM }
+      IMG src="images/cat.gif"
+
+      / slim-lint:disable TagCase
+      IMG src="images/cat.gif"
+      / slim-lint:enable TagCase
+
+      IMG src="images/cat.gif"
+    SLIM
+
+    it "handles the enable/disable config comment properly when reusing the linter" do
+      first_document = SlimLint::Document.new(normalize_indent(first_file), config: config)
+      subject.run(first_document)
+
+      expect(subject).to report_lint line: 1
+
+      second_document = SlimLint::Document.new(normalize_indent(second_file), config: config)
+      subject.run(second_document)
+
+      expect(subject).to report_lint line: 1
+      expect(subject).to_not report_lint line: 4
+      expect(subject).to report_lint line: 7
+    end
   end
 end


### PR DESCRIPTION
When running slim-lint across multiple files, a linter would incorrectly cache which lines it was disabled for on the first file and re-use those lines for the rest of the files. This caused linters to be enabled or disabled for the wrong lines in any additional files.