### PR TITLE
Add linter for zwsp detection

### DIFF
--- a/lib/slim_lint/linter/README.md
+++ b/lib/slim_lint/linter/README.md
@@ -16,6 +16,7 @@ Below is a list of linters supported by `slim-lint`, ordered alphabetically.
 * [TagCase](#tagcase)
 * [TrailingBlankLines](#trailingblanklines)
 * [TrailingWhitespace](#trailingwhitespace)
+* [Zwsp](#zwsp)
 
 ## CommentControlStatement
 
@@ -273,3 +274,19 @@ Reports trailing blank lines.
 ## TrailingWhitespace
 
 Reports trailing whitespace (spaces or tabs) on any lines in a Slim document.
+
+## Zwsp
+
+Reports it contains ZWSP(zero width space).
+
+**Bad**
+
+```slim
+| Hello Zwsp\u200b
+```
+
+**Good**
+
+```slim
+| Hello without zwsp
+```

--- a/lib/slim_lint/linter/zwsp.rb
+++ b/lib/slim_lint/linter/zwsp.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SlimLint
+  class Linter::Zwsp < Linter
+    include LinterRegistry
+
+    MSG = 'Remove Zwsp'
+
+    on_start do |_sexp|
+      dummy_node = Struct.new(:line)
+      document.source_lines.each_with_index do |line, index|
+        next unless line.include?("\u200b")
+
+        report_lint(dummy_node.new(index + 1), MSG)
+      end
+    end
+  end
+end

--- a/spec/slim_lint/linter/zwsp_spec.rb
+++ b/spec/slim_lint/linter/zwsp_spec.rb
@@ -10,7 +10,7 @@ describe SlimLint::Linter::Tab do
       | Hello ZWSP\u200b
     SLIM
 
-    it { should_not report_lint line: 1 }
+    it { should report_lint line: 1 }
   end
 
   context 'when without ZWSP' do

--- a/spec/slim_lint/linter/zwsp_spec.rb
+++ b/spec/slim_lint/linter/zwsp_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SlimLint::Linter::Tab do
+  include_context 'linter'
+
+  context 'when with ZWSP' do
+    let(:slim) { <<-SLIM }
+      | Hello ZWSP\u200b
+    SLIM
+
+    it { should_not report_lint line: 1 }
+  end
+
+  context 'when without ZWSP' do
+    let(:slim) { <<-SLIM }
+      | Hello without ZWSP
+    SLIM
+
+    it { should_not report_lint }
+  end
+end


### PR DESCRIPTION
Hello, thanks for this nice gem!

This change added a linter that can detect ZWSP.

ZWSP( `U+200B` ZERO-WIDTH SPACE) may be treated as a wbr tag.(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)
In that case, unnecessary line breaks may occur.

ZWSP can be entered unintentionally by copying and pasting strings from Microsoft Office software.
However, it is not displayed in some editors such as VScode and I can not notice it.
So you need this linter.

I’d appreciate if you could give me feedback. Thank you.