### PR TITLE
Support Slim 5

### DIFF
--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4.0'
 
   s.add_dependency 'rubocop', '>= 0.78.0'
-  s.add_runtime_dependency 'slim', ['>= 3.0', '< 5.0']
+  s.add_runtime_dependency 'slim', ['>= 3.0', '< 6.0']
 
   s.add_development_dependency 'pry', '~> 0.13'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
This commit changes the dependency to the `slim` gem to allow using its version 5.0, that was [released on the 23rd of January 2022][0]

[0]: https://rubygems.org/gems/slim/versions/5.0.0