### PR TITLE
Don't enable Zwsp by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -96,4 +96,4 @@ linters:
     enabled: true
 
   Zwsp:
-    enabled: true
+    enabled: false


### PR DESCRIPTION
This was accidentally enabled while debugging 633c112b.
