### PR TITLE
Cut version 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slim-Lint Changelog
 
-## Unreleased
+## 0.26.0
 
 * Revert "Fix `ControlSpacingStatement` linter handling of `=` in some cases"
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 # Run all pre-commit hooks via Overcommit during CI runs
-gem 'overcommit', '0.60.0'
+gem 'overcommit', '0.62.0'
 
 # Needed for Rake integration tests
 gem 'rake'
@@ -15,5 +15,4 @@ gem 'rubocop', '>= 1', '< 2'
 
 gem 'simplecov', require: false
 
-# On Ruby 3, rexml is only a gem
-gem 'rexml' if RUBY_VERSION > '3'
+gem 'rexml'

--- a/lib/slim_lint/version.rb
+++ b/lib/slim_lint/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module SlimLint
-  VERSION = '0.25.0'
+  VERSION = '0.26.0'
 end


### PR DESCRIPTION
Sneaking in here is a minor update to our CI environment (the `overcommit` version we use) but otherwise is a revert of code that introduced a bug.
