### PR TITLE
Add Tag linter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -98,6 +98,10 @@ linters:
   Tab:
     enabled: true
 
+  Tag:
+    enabled: false
+    forbidden_tags: []
+
   TagCase:
     enabled: true
 

--- a/lib/slim_lint/linter/README.md
+++ b/lib/slim_lint/linter/README.md
@@ -15,6 +15,7 @@ Below is a list of linters supported by `slim-lint`, ordered alphabetically.
 * [RuboCop](#rubocop)
 * [StrictLocalsMissing](#strictlocalsmissing)
 * [Tab](#tab)
+* [Tag](#tag)
 * [TagCase](#tagcase)
 * [TrailingBlankLines](#trailingblanklines)
 * [TrailingWhitespace](#trailingwhitespace)
@@ -319,6 +320,28 @@ for the template that shows which local variables it accepts.
 ## Tab
 
 Reports detection of tabs used for indentation.
+
+## Tag
+
+Reports forbidden tag if listed.
+
+Option | Description
+-------|-----------------------------------------------------------------
+`forbidden_tags`  | List of forbidden tags. (default [])
+
+```yaml
+linters:
+  Tag:
+    enabled: true
+    forbidden_tags:
+      - p
+```
+
+**Bad for above configuration**
+```slim
+p Something
+P Something else
+```
 
 ## TagCase
 

--- a/lib/slim_lint/linter/tag.rb
+++ b/lib/slim_lint/linter/tag.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SlimLint
+  # Checks for forbidden tags.
+  class Linter::Tag < Linter
+    include LinterRegistry
+
+    on [:html, :tag] do |sexp|
+      _, _, name = sexp
+
+      forbidden_tags = config['forbidden_tags']
+      forbidden_tags.each do |forbidden_tag|
+        next unless name[/^#{forbidden_tag}$/i]
+
+        report_lint(sexp, "Forbidden tag `#{name}` found")
+      end
+    end
+  end
+end

--- a/spec/slim_lint/linter/tag_spec.rb
+++ b/spec/slim_lint/linter/tag_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SlimLint::Linter::Tag do
+  include_context 'linter'
+
+  context 'when a lowercased tag is contained in forbidden_tags' do
+    let(:config) do
+      { 'forbidden_tags' => %w[a] }
+    end
+
+    let(:slim) { 'a href="/foo"' }
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when an uppercased tag is contained in forbidden_tags' do
+    let(:config) do
+      { 'forbidden_tags' => %w[a] }
+    end
+
+    let(:slim) { 'A href="/foo"' }
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a tag is not contained in forbidden_tags' do
+    let(:config) do
+      { 'forbidden_tags' => %w[a] }
+    end
+
+    let(:slim) { 'textarea name="foo"' }
+
+    it { should_not report_lint }
+  end
+end


### PR DESCRIPTION
Add a `Tag` linter to forbid the use of the specified tag. The following use cases are considered.

* Forbid `style` tags and use the `css` embedded engine or css file instead.
* Forbid the `a` tags and use Rails' `link_to` helper instead.