### PR TITLE
Add TagAttribute linter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -102,6 +102,10 @@ linters:
     enabled: false
     forbidden_tags: []
 
+  TagAttribute:
+    enabled: false
+    forbidden_attributes: []
+
   TagCase:
     enabled: true
 

--- a/lib/slim_lint/linter/README.md
+++ b/lib/slim_lint/linter/README.md
@@ -16,6 +16,7 @@ Below is a list of linters supported by `slim-lint`, ordered alphabetically.
 * [StrictLocalsMissing](#strictlocalsmissing)
 * [Tab](#tab)
 * [Tag](#tag)
+* [TagAttribute](#tagattribute)
 * [TagCase](#tagcase)
 * [TrailingBlankLines](#trailingblanklines)
 * [TrailingWhitespace](#trailingwhitespace)
@@ -341,6 +342,28 @@ linters:
 ```slim
 p Something
 P Something else
+```
+
+## TagAttribute
+
+Reports forbidden tag attribute if listed.
+
+Option | Description
+-------|-----------------------------------------------------------------
+`forbidden_attributes`  | List of forbidden tag attributes. (default [])
+
+```yaml
+linters:
+  TagAttribute:
+    enabled: true
+    forbidden_attributes:
+      - style
+```
+
+**Bad for above configuration**
+```slim
+p style="{ color: red; }" Something
+P STYLE="{ color: blue; }" Something else
 ```
 
 ## TagCase

--- a/lib/slim_lint/linter/tag_attribute.rb
+++ b/lib/slim_lint/linter/tag_attribute.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SlimLint
+  # Checks for forbidden tag attributes.
+  class Linter::TagAttribute < Linter
+    include LinterRegistry
+
+    on [:html, :attr] do |sexp|
+      _, _, name = sexp
+
+      forbidden_attributes = config['forbidden_attributes']
+      forbidden_attributes.each do |forbidden_attribute|
+        next unless name[/^#{forbidden_attribute}$/i]
+
+        report_lint(sexp, "Forbidden tag attribute `#{name}` found")
+      end
+    end
+  end
+end

--- a/spec/slim_lint/linter/tag_attribute_spec.rb
+++ b/spec/slim_lint/linter/tag_attribute_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SlimLint::Linter::TagAttribute do
+  include_context 'linter'
+
+  context 'when a lowercased attribute is contained in forbidden_attributes' do
+    let(:config) do
+      { 'forbidden_attributes' => %w[style] }
+    end
+
+    let(:slim) { 'p style="{ color: red; }"' }
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when an uppercased attribute is contained in forbidden_attributes' do
+    let(:config) do
+      { 'forbidden_attributes' => %w[style] }
+    end
+
+    let(:slim) { 'P STYLE="{ color: red; }"' }
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when an attribute is not contained in forbidden_attributes' do
+    let(:config) do
+      { 'forbidden_attributes' => %w[style] }
+    end
+
+    let(:slim) { 'style media="all"' }
+
+    it { should_not report_lint }
+  end
+end


### PR DESCRIPTION
Add a `TagAttribute` linter to forbid the use of the specified tag attribute. The following use cases are considered.

* Forbid `style=""` attribute and use the css embedded engine or css file instead.
* Forbid `class=""` attribute and use `.class` syntax instead.