### PR TITLE
Add rexml as explicit dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,3 @@ gem 'rake'
 gem 'rubocop', '>= 1', '< 2'
 
 gem 'simplecov', require: false
-
-gem 'rexml'

--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0'
 
+  s.add_runtime_dependency 'rexml', '~> 3.2'
   s.add_runtime_dependency 'rubocop', ['>= 1.0', '< 2.0']
   s.add_runtime_dependency 'slim', ['>= 3.0', '< 6.0']
 


### PR DESCRIPTION
This is necessary as of RuboCop 1.66.0, which dropped its dependency on `rexml`.
