### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/slim_lint.rb
+++ b/lib/slim_lint.rb
@@ -6,37 +6,37 @@
 # Need to load slim before we can reference some classes or define filters
 require 'slim'
 
-require 'slim_lint/constants'
-require 'slim_lint/exceptions'
-require 'slim_lint/configuration'
-require 'slim_lint/configuration_loader'
-require 'slim_lint/utils'
-require 'slim_lint/atom'
-require 'slim_lint/sexp'
-require 'slim_lint/file_finder'
-require 'slim_lint/linter_registry'
-require 'slim_lint/logger'
-require 'slim_lint/version'
+require_relative 'slim_lint/constants'
+require_relative 'slim_lint/exceptions'
+require_relative 'slim_lint/configuration'
+require_relative 'slim_lint/configuration_loader'
+require_relative 'slim_lint/utils'
+require_relative 'slim_lint/atom'
+require_relative 'slim_lint/sexp'
+require_relative 'slim_lint/file_finder'
+require_relative 'slim_lint/linter_registry'
+require_relative 'slim_lint/logger'
+require_relative 'slim_lint/version'
 
 # Load all filters (required by SlimLint::Engine)
 Dir[File.expand_path('slim_lint/filters/*.rb', File.dirname(__FILE__))].sort.each do |file|
   require file
 end
 
-require 'slim_lint/engine'
-require 'slim_lint/document'
-require 'slim_lint/capture_map'
-require 'slim_lint/sexp_visitor'
-require 'slim_lint/lint'
-require 'slim_lint/ruby_parser'
-require 'slim_lint/linter'
-require 'slim_lint/reporter'
-require 'slim_lint/report'
-require 'slim_lint/linter_selector'
-require 'slim_lint/runner'
+require_relative 'slim_lint/engine'
+require_relative 'slim_lint/document'
+require_relative 'slim_lint/capture_map'
+require_relative 'slim_lint/sexp_visitor'
+require_relative 'slim_lint/lint'
+require_relative 'slim_lint/ruby_parser'
+require_relative 'slim_lint/linter'
+require_relative 'slim_lint/reporter'
+require_relative 'slim_lint/report'
+require_relative 'slim_lint/linter_selector'
+require_relative 'slim_lint/runner'
 
 # Load all matchers
-require 'slim_lint/matcher/base'
+require_relative 'slim_lint/matcher/base'
 Dir[File.expand_path('slim_lint/matcher/*.rb', File.dirname(__FILE__))].sort.each do |file|
   require file
 end

--- a/lib/slim_lint/cli.rb
+++ b/lib/slim_lint/cli.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'slim_lint'
-require 'slim_lint/options'
+require_relative '../slim_lint'
+require_relative 'options'
 
 module SlimLint
   # Command line application interface.

--- a/lib/slim_lint/linter/rubocop.rb
+++ b/lib/slim_lint/linter/rubocop.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require 'slim_lint/ruby_extractor'
-require 'slim_lint/ruby_extract_engine'
+require_relative '../ruby_extractor'
+require_relative '../ruby_extract_engine'
+
 require 'rubocop'
 
 module SlimLint

--- a/lib/slim_lint/rake_task.rb
+++ b/lib/slim_lint/rake_task.rb
@@ -2,7 +2,8 @@
 
 require 'rake'
 require 'rake/tasklib'
-require 'slim_lint/constants'
+
+require_relative 'constants'
 
 module SlimLint
   # Rake task interface for slim-lint command line interface.
@@ -74,8 +75,8 @@ module SlimLint
 
       task(name, [:files]) do |_task, task_args|
         # Lazy-load so task doesn't affect Rakefile load time
-        require 'slim_lint'
-        require 'slim_lint/cli'
+        require_relative '../slim_lint'
+        require_relative 'cli'
 
         run_cli(task_args)
       end


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Retain `require` for dynamic paths in `lib/slim_lint.rb` because they use absolute paths.

Refs:
- rubocop/rubocop#8748
- sds/haml-lint#521