### PR TITLE
Include StringIO in Rubocop linter

### DIFF
--- a/lib/slim_lint/linter/rubocop.rb
+++ b/lib/slim_lint/linter/rubocop.rb
@@ -4,6 +4,7 @@ require_relative '../ruby_extractor'
 require_relative '../ruby_extract_engine'
 
 require 'rubocop'
+require 'stringio'
 
 module SlimLint
   # Runs RuboCop on Ruby code extracted from Slim templates.


### PR DESCRIPTION
I am running into the following issue when running ruby 3.3.5 with slim lint:

```bash
# SLIM_LINT_RUBOCOP_CONF=.slim-lint-rubocop.yml ./bin/bundle exec slim-lint app/views
uninitialized constant SlimLint::Linter::RuboCop::StringIO
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/linter/rubocop.rb:84:in `with_ruby_from_stdin'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/linter/rubocop.rb:37:in `find_lints'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/linter/rubocop.rb:21:in `block in <class:RuboCop>'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/sexp_visitor.rb:12:in `trigger_pattern_callbacks'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/linter.rb:33:in `run'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/runner.rb:64:in `block in collect_lints'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/runner.rb:63:in `map'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/runner.rb:63:in `collect_lints'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/runner.rb:23:in `block in run'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/runner.rb:22:in `map'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/runner.rb:22:in `run'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/cli.rb:91:in `scan_for_lints'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/cli.rb:60:in `act_on_options'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/lib/slim_lint/cli.rb:32:in `run'
/Users/rbclark/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/slim_lint-0.31.0/bin/slim-lint:7:in `<top (required)>'
```

This seems to be happening specifically due to my psych version updating from `5.1.2` -> `5.2.0`.

Explicitly requiring `stringio` has fixed the error for me.