### PR TITLE
Cut version 0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slim-Lint Changelog
 
+## 0.31.1
+
+* Fix loading of `RuboCop` linter on Ruby 3.3.5+
+
 ## 0.31.0
 
 * Add GitHub reporter

--- a/lib/slim_lint/version.rb
+++ b/lib/slim_lint/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module SlimLint
-  VERSION = '0.31.0'
+  VERSION = '0.31.1'
 end


### PR DESCRIPTION
* Fix loading of `RuboCop` linter on Ruby 3.3.5+