### PR TITLE
CI: Add Ruby 3.4, drop Ruby 3.0 (EOL)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - "3.4"
           - "3.3"
           - "3.2"
           - "3.1"
-          - "3.0"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

