### PR TITLE
Simplify QuoteConsistency by utilizing html matcher

### DIFF
--- a/lib/slim_lint/linter/README.md
+++ b/lib/slim_lint/linter/README.md
@@ -234,10 +234,9 @@ Long lines are harder to read and usually indicative of complexity.
 
 Reports inconsistent quote usage.
 
-| Option            | Description                                 |
-| ----------------- | ------------------------------------------- |
-| `enforced_style`  | Style to enforce. (default `single_quotes`) |
-| `skip_ruby_lines` | Skips linting Ruby lines. (default `true`)  |
+| Option           | Description                                 |
+| ---------------- | ------------------------------------------- |
+| `enforced_style` | Style to enforce. (default `single_quotes`) |
 
 ### Enforced Style
 
@@ -271,35 +270,13 @@ p style="{ color: red; }" Something
 p style='color: red;' Something
 ```
 
-### Skip Ruby Lines
+### Nested Quotes
 
-By default, the linter will skip Ruby lines. This is to prevent issues with
-RuboCop checking the same lines.
-
-#### skip_ruby_lines: true
-
-**Good**
-
-```slim
-- title = "Hello World"
-```
-
-#### skip_ruby_lines: false
-
-**Bad**
-
-```slim
-- title = "Hello World"
-```
-
-### Exceptions
-
-Comments and nested quotes are exempt from this linter.
+Nested quotes are exempt from this linter.
 
 The following is valid:
 
 ```slim
-/ This is a "comment"
 a href='javascript:void(0)' onclick="$('#create-modal').modal('show')"
 ```
 

--- a/lib/slim_lint/linter/quote_consistency.rb
+++ b/lib/slim_lint/linter/quote_consistency.rb
@@ -7,29 +7,22 @@ module SlimLint
 
     MSG = 'Inconsistent quote style. %s'
 
-    on_start do |_sexp|
-      dummy_node = Struct.new(:line)
-      document.source_lines.each_with_index do |line, index|
-        # Skip lines without any quotes
-        next unless line =~ /['"]/
+    on [:html, :attrs] do |node|
+      line = document.source_lines[node.line - 1]
 
-        # Skip comments
-        next if line =~ %r{^\s*(/{1,3})}
+      # Skip lines without any quotes
+      next unless line =~ /['"]/
 
-        # Skip Ruby lines that RuboCop will check
-        next if skip_ruby_lines && line =~ /^\s*[=-]/
+      # Find all quoted strings in attributes (ignoring nested quotes)
+      single_quotes = line.scan(/^(?:[^'"]*'[^'"]*'[^'"]*)?(?:[^'"]*)('[^'"]*')/)
+      double_quotes = line.scan(/^(?:[^'"]*'[^'"]*'[^'"]*)?(?:[^'"]*)("[^'"]*")/)
 
-        # Find all quoted strings in attributes (ignoring nested quotes)
-        single_quotes = line.scan(/^(?:[^'"]*'[^'"]*'[^'"]*)?(?:[^'"]*)('[^'"]*')/)
-        double_quotes = line.scan(/^(?:[^'"]*'[^'"]*'[^'"]*)?(?:[^'"]*)("[^'"]*")/)
-
-        if enforced_style == :single_quotes && double_quotes.any?
-          report_lint(dummy_node.new(index + 1),
-                      format(MSG, "Use single quotes for attribute values (')"))
-        elsif enforced_style == :double_quotes && single_quotes.any?
-          report_lint(dummy_node.new(index + 1),
-                      format(MSG, 'Use double quotes for attribute values (")'))
-        end
+      if enforced_style == :single_quotes && double_quotes.any?
+        report_lint(node,
+                    format(MSG, "Use single quotes for attribute values (')"))
+      elsif enforced_style == :double_quotes && single_quotes.any?
+        report_lint(node,
+                    format(MSG, 'Use double quotes for attribute values (")'))
       end
     end
 
@@ -37,10 +30,6 @@ module SlimLint
 
     def enforced_style
       config['enforced_style']&.to_sym || :single_quotes
-    end
-
-    def skip_ruby_lines
-      config.fetch('skip_ruby_lines', true)
     end
   end
 end

--- a/spec/slim_lint/linter/quote_consistency_spec.rb
+++ b/spec/slim_lint/linter/quote_consistency_spec.rb
@@ -67,7 +67,7 @@ describe SlimLint::Linter::QuoteConsistency do
 
   context 'when line has multiple quoted strings' do
     let(:slim) { <<-SLIM }
-      .input name='name' value="value"
+      .input name='test-name' value="test-value"
     SLIM
 
     it { should report_lint line: 1 }
@@ -86,16 +86,6 @@ describe SlimLint::Linter::QuoteConsistency do
       - title = "Hello World"
     SLIM
 
-    context 'when skip_ruby_lines is true' do
-      let(:config) { { 'skip_ruby_lines' => true } }
-
-      it { should_not report_lint }
-    end
-
-    context 'when skip_ruby_lines is false' do
-      let(:config) { { 'skip_ruby_lines' => false } }
-
-      it { should report_lint line: 1 }
-    end
+    it { should_not report_lint }
   end
 end


### PR DESCRIPTION
Instead of using `on_start`, this MR changes `QuoteConsistency` to use `on [:html, :attrs]` to simplify checking for quotes only on html blocks.

This fixes multiline ruby blocks being scanned for quotes.