### PR TITLE
CI: Add Ruby 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - "4.0"
           - "3.4"
           - "3.3"
           - "3.2"


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.