### PR TITLE
Fix ControlStatementSpacing false positive after multi-line attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Slim-Lint Changelog
 
+## master (unreleased)
+
+* Fix `ControlStatementSpacing` reporting false positives after an attribute
+  that spans multiple lines using a backslash (`\`) continuation
+
 ## 0.34.0
 
 * Add check for invalid keys in config files

--- a/lib/slim_lint/linter/control_statement_spacing.rb
+++ b/lib/slim_lint/linter/control_statement_spacing.rb
@@ -11,10 +11,11 @@ module SlimLint
     on [:html, :tag, anything, [],
          [:slim, :output, anything, capture(:ruby, anything)]] do |sexp|
       # Fetch original Slim code that contains an element with a control statement.
-      line = document.source_lines[sexp.line - 1]
+      ruby = captures[:ruby]
+      line = source_line_for(sexp, /=[=<>]* *#{Regexp.escape(ruby[/[^\n]*/])}/)
+      next unless line
 
       # Remove any Ruby code, because our regexp below must not match inside Ruby.
-      ruby = captures[:ruby]
       line = line.sub(ruby, 'x')
 
       next if line =~ /[^ ] ==?<?>? [^ ]/
@@ -23,11 +24,33 @@ module SlimLint
     end
 
     on [:slim, :control] do |sexp|
-      line = document.source_lines[sexp.line - 1]
+      ruby = sexp[2]
+      line = source_line_for(sexp, /- *#{Regexp.escape(ruby[/[^\n]*/])}/)
+      next unless line
 
       next if line =~ /^ *- [^ ]/
 
       report_lint(sexp, MESSAGE_CONTROL)
+    end
+
+    private
+
+    # Finds the original Slim source line for the given Sexp.
+    #
+    # Backslash (`\`) and comma (`,`) line continuations in preceding
+    # attributes are collapsed by the Slim parser without emitting a newline,
+    # which causes the line number reported for subsequent Sexps to be too low
+    # (see https://github.com/sds/slim-lint/issues/201). We compensate by
+    # searching forward from the reported line for the line that actually
+    # contains the statement, falling back to the reported line otherwise.
+    #
+    # @param sexp [SlimLint::Sexp]
+    # @param pattern [Regexp] matches the source line containing the statement
+    # @return [String, nil]
+    def source_line_for(sexp, pattern)
+      index = sexp.line - 1
+      lines = document.source_lines[index..] || []
+      lines.find { |line| line =~ pattern } || document.source_lines[index]
     end
   end
 end

--- a/spec/slim_lint/linter/control_statement_spacing_spec.rb
+++ b/spec/slim_lint/linter/control_statement_spacing_spec.rb
@@ -340,4 +340,51 @@ describe SlimLint::Linter::ControlStatementSpacing do
       it { should report_lint }
     end
   end
+
+  # Backslash line continuations in a preceding attribute are collapsed by the
+  # Slim parser, which shifts the reported line number of subsequent
+  # statements. See https://github.com/sds/slim-lint/issues/201.
+  context 'when a preceding attribute spans multiple lines' do
+    context 'and the control statement has appropriate spacing' do
+      let(:slim) { <<~'SLIM' }
+        div class="a \
+         b"
+          - if 1 == 2
+            | Hello
+      SLIM
+
+      it { should_not report_lint }
+    end
+
+    context 'and the control statement is missing spacing' do
+      let(:slim) { <<~'SLIM' }
+        div class="a \
+         b"
+          -if 1 == 2
+            | Hello
+      SLIM
+
+      it { should report_lint }
+    end
+
+    context 'and the output statement has appropriate spacing' do
+      let(:slim) { <<~'SLIM' }
+        div class="a \
+         b"
+          span = foo
+      SLIM
+
+      it { should_not report_lint }
+    end
+
+    context 'and the output statement is missing spacing' do
+      let(:slim) { <<~'SLIM' }
+        div class="a \
+         b"
+          span= foo
+      SLIM
+
+      it { should report_lint }
+    end
+  end
 end


### PR DESCRIPTION
When an attribute uses a backslash (`\`) or comma line continuation, the Slim parser collapses the continued lines without emitting a newline. Since slim-lint derives line numbers by counting newline sexps, the reported line number for subsequent control/output statements is too low, causing ControlStatementSpacing to inspect the wrong source line and emit a false `Please add a space after the -` warning.

Locate the real source line by searching forward from the reported line for the line that actually contains the statement.

Fixes #201

This commit was made with the help of a LLM. I have checked the code myself, and can vouch for it. 
Also, I ran it towards our project which has 25k loc of slim, and it ran perfectly. It only pointed out a couple of `space after the -` mistakes that actually should be fixed. 