### PR TITLE
Add metadata to gemspec and opt-in for MFA

### DIFF
--- a/slim_lint.gemspec
+++ b/slim_lint.gemspec
@@ -24,6 +24,13 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0'
 
+  s.metadata = {
+    'bug_tracker_uri' => 'https://github.com/sds/slim-lint/issues',
+    'changelog_uri' => 'https://github.com/sds/slim-lint/blob/main/CHANGELOG.md',
+    'source_code_uri' => 'https://github.com/sds/slim-lint',
+    'rubygems_mfa_required' => 'true'
+  }
+
   s.add_runtime_dependency 'rexml', '~> 3.2'
   s.add_runtime_dependency 'rubocop', ['>= 1.0', '< 2.0']
   s.add_runtime_dependency 'slim', ['>= 3.0', '< 6.0']


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `source_code_uri`, and `rubygems_mfa_required` metadata to the gemspec for parity with `haml-lint` and to opt-in for MFA requirement.

Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref:
- https://guides.rubygems.org/mfa-requirement-opt-in/
- sds/haml-lint#679